### PR TITLE
HUD code refactoring

### DIFF
--- a/cl_dll/CHud.cpp
+++ b/cl_dll/CHud.cpp
@@ -417,17 +417,8 @@ void CHud :: Init( void )
 	m_pSpriteList = NULL;
 
 	// Clear any old HUD list
-	if ( m_pHudList )
-	{
-		HUDLIST *pList;
-		while ( m_pHudList )
-		{
-			pList = m_pHudList;
-			m_pHudList = m_pHudList->pNext;
-			free( pList );
-		}
-		m_pHudList = NULL;
-	}
+	for (CHudBase *i : m_HudList) if (i->m_isDeletable) delete i;
+	m_HudList.clear();
 
 	// In case we get messages before the first update -- time will be valid
 	m_flTime = 1.0;
@@ -437,22 +428,6 @@ void CHud :: Init( void )
 	m_hudColor2.Set(255, 160, 0);
 	m_hudColor3.Set(255, 96, 0);
 
-	/*m_Ammo->Init();
-	m_Health->Init();
-	m_SayText->Init();
-	m_Spectator->Init();
-	m_Geiger->Init();
-	m_Train->Init();
-	m_Battery->Init();
-	m_Flash->Init();
-	m_Message->Init();
-	m_StatusBar->Init();
-	m_DeathNotice->Init();
-	m_AmmoSecondary->Init();
-	m_TextMessage->Init();
-	m_StatusIcons->Init();
-	m_Timer->Init();
-	m_Scores->Init();*/
 	HUD_ELEM_INIT(Ammo);
 	HUD_ELEM_INIT(Health);
 	HUD_ELEM_INIT(SayText);
@@ -491,6 +466,12 @@ void CHud :: Init( void )
 	MsgFunc_ResetHUD(0, 0, NULL );
 }
 
+// CHud constructor
+CHud::CHud() : m_iSpriteCount(0)
+{
+	
+}
+
 // CHud destructor
 // cleans up memory allocated for m_rg* arrays
 CHud :: ~CHud()
@@ -499,17 +480,8 @@ CHud :: ~CHud()
 	delete [] m_rgrcRects;
 	delete [] m_rgszSpriteNames;
 
-	if ( m_pHudList )
-	{
-		HUDLIST *pList;
-		while ( m_pHudList )
-		{
-			pList = m_pHudList;
-			m_pHudList = m_pHudList->pNext;
-			free( pList );
-		}
-		m_pHudList = NULL;
-	}
+	for (CHudBase *i : m_HudList) if (i->m_isDeletable) delete i;
+	m_HudList.clear();
 
 	CharWidths* cur = m_CharWidths.next;
 	CharWidths* next;
@@ -827,34 +799,10 @@ int CHud::MsgFunc_SetFOV(const char *pszName,  int iSize, void *pbuf)
 }
 
 
-void CHud::AddHudElem(CHudBase *phudelem)
+void CHud::AddHudElem(CHudBase *elem)
 {
-	HUDLIST *pdl, *ptemp;
-
-//phudelem->Think();
-
-	if (!phudelem)
-		return;
-
-	pdl = (HUDLIST *)malloc(sizeof(HUDLIST));
-	if (!pdl)
-		return;
-
-	memset(pdl, 0, sizeof(HUDLIST));
-	pdl->p = phudelem;
-
-	if (!m_pHudList)
-	{
-		m_pHudList = pdl;
-		return;
-	}
-
-	ptemp = m_pHudList;
-
-	while (ptemp->pNext)
-		ptemp = ptemp->pNext;
-
-	ptemp->pNext = pdl;
+	if (!elem) return;
+	m_HudList.push_back(elem);
 }
 
 float CHud::GetSensitivity( void )

--- a/cl_dll/CHud.cpp
+++ b/cl_dll/CHud.cpp
@@ -33,6 +33,26 @@
 #include "vgui_scorepanel.h"
 #include "appversion.h"
 
+//-----------------------------------------------------
+// HUD elements
+//-----------------------------------------------------
+#include "CHudSpectator.h"
+#include "CHudAmmo.h"
+#include "CHudAmmoSecondary.h"
+#include "CHudHealth.h"
+#include "CHudGeiger.h"
+#include "CHudTrain.h"
+#include "CHudStatusBar.h"
+#include "CHudDeathNotice.h"
+#include "CHudMenu.h"
+#include "CHudSayText.h"
+#include "CHudBattery.h"
+#include "CHudFlashlight.h"
+#include "CHudTextMessage.h"
+#include "CHudMessage.h"
+#include "CHudTimer.h"
+#include "CHudScores.h"
+#include "CHudStatusIcons.h"
 
 float g_ColorBlue[3]	= { 0.6f, 0.8f, 1.0f };
 float g_ColorRed[3]		= { 1.0f, 0.25f, 0.25f };
@@ -223,7 +243,7 @@ void __CmdFunc_ForceColors(void)
 
 void __CmdFunc_CustomTimer(void)
 {
-	gHUD.m_Timer.CustomTimerCommand();
+	gHUD.m_Timer->CustomTimerCommand();
 }
 
 // TFFree Command Menu Message Handlers
@@ -417,22 +437,38 @@ void CHud :: Init( void )
 	m_hudColor2.Set(255, 160, 0);
 	m_hudColor3.Set(255, 96, 0);
 
-	m_Ammo.Init();
-	m_Health.Init();
-	m_SayText.Init();
-	m_Spectator.Init();
-	m_Geiger.Init();
-	m_Train.Init();
-	m_Battery.Init();
-	m_Flash.Init();
-	m_Message.Init();
-	m_StatusBar.Init();
-	m_DeathNotice.Init();
-	m_AmmoSecondary.Init();
-	m_TextMessage.Init();
-	m_StatusIcons.Init();
-	m_Timer.Init();
-	m_Scores.Init();
+	/*m_Ammo->Init();
+	m_Health->Init();
+	m_SayText->Init();
+	m_Spectator->Init();
+	m_Geiger->Init();
+	m_Train->Init();
+	m_Battery->Init();
+	m_Flash->Init();
+	m_Message->Init();
+	m_StatusBar->Init();
+	m_DeathNotice->Init();
+	m_AmmoSecondary->Init();
+	m_TextMessage->Init();
+	m_StatusIcons->Init();
+	m_Timer->Init();
+	m_Scores->Init();*/
+	HUD_ELEM_INIT(Ammo);
+	HUD_ELEM_INIT(Health);
+	HUD_ELEM_INIT(SayText);
+	HUD_ELEM_INIT(Spectator);
+	HUD_ELEM_INIT(Geiger);
+	HUD_ELEM_INIT(Train);
+	HUD_ELEM_INIT(Battery);
+	HUD_ELEM_INIT_FULL(CHudFlashlight, m_Flash);
+	HUD_ELEM_INIT(Message);
+	HUD_ELEM_INIT(StatusBar);
+	HUD_ELEM_INIT(DeathNotice);
+	HUD_ELEM_INIT(AmmoSecondary);
+	HUD_ELEM_INIT(TextMessage);
+	HUD_ELEM_INIT(StatusIcons);
+	HUD_ELEM_INIT(Timer);
+	HUD_ELEM_INIT(Scores);
 
 	if (g_iIsAg)
 	{
@@ -450,11 +486,8 @@ void CHud :: Init( void )
 	}
 
 	GetClientVoiceMgr()->Init(&g_VoiceStatusHelper, (vgui::Panel**)&gViewPort);
-
-	m_Menu.Init();
-	
+	HUD_ELEM_INIT(Menu);
 	ServersInit();
-
 	MsgFunc_ResetHUD(0, 0, NULL );
 }
 
@@ -575,23 +608,23 @@ void CHud :: VidInit( void )
 
 	m_iFontHeight = m_rgrcRects[m_HUD_number_0].bottom - m_rgrcRects[m_HUD_number_0].top;
 
-	m_Ammo.VidInit();
-	m_Health.VidInit();
-	m_Spectator.VidInit();
-	m_Geiger.VidInit();
-	m_Train.VidInit();
-	m_Battery.VidInit();
-	m_Flash.VidInit();
-	m_Message.VidInit();
-	m_StatusBar.VidInit();
-	m_DeathNotice.VidInit();
-	m_SayText.VidInit();
-	m_Menu.VidInit();
-	m_AmmoSecondary.VidInit();
-	m_TextMessage.VidInit();
-	m_StatusIcons.VidInit();
-	m_Timer.VidInit();
-	m_Scores.VidInit();
+	m_Ammo->VidInit();
+	m_Health->VidInit();
+	m_Spectator->VidInit();
+	m_Geiger->VidInit();
+	m_Train->VidInit();
+	m_Battery->VidInit();
+	m_Flash->VidInit();
+	m_Message->VidInit();
+	m_StatusBar->VidInit();
+	m_DeathNotice->VidInit();
+	m_SayText->VidInit();
+	m_Menu->VidInit();
+	m_AmmoSecondary->VidInit();
+	m_TextMessage->VidInit();
+	m_StatusIcons->VidInit();
+	m_Timer->VidInit();
+	m_Scores->VidInit();
 
 	if (g_iIsAg)
 	{

--- a/cl_dll/CHud.cpp
+++ b/cl_dll/CHud.cpp
@@ -473,15 +473,12 @@ CHud::CHud() : m_iSpriteCount(0)
 }
 
 // CHud destructor
-// cleans up memory allocated for m_rg* arrays
+// frees allocated dynamic memory
 CHud :: ~CHud()
 {
 	delete [] m_rghSprites;
 	delete [] m_rgrcRects;
 	delete [] m_rgszSpriteNames;
-
-	for (CHudBase *i : m_HudList) if (i->m_isDeletable) delete i;
-	m_HudList.clear();
 
 	CharWidths* cur = m_CharWidths.next;
 	CharWidths* next;

--- a/cl_dll/CHudAmmo.cpp
+++ b/cl_dll/CHudAmmo.cpp
@@ -18,6 +18,7 @@
 // implementation of CHudAmmo class
 //
 
+#include "CHudAmmo.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
@@ -28,6 +29,7 @@
 
 #include "ammohistory.h"
 #include "vgui_TeamFortressViewport.h"
+#include "CHudMenu.h"
 
 WEAPON *gpActiveSel;	// NULL means off, 1 means just the menu bar, otherwise
 						// this points to the active weapon menu item
@@ -238,27 +240,27 @@ int giBucketHeight, giBucketWidth, giABHeight, giABWidth; // Ammo Bar width and 
 
 HLHSPRITE ghsprBuckets;					// Sprite for top row of weapons menu
 
-DECLARE_MESSAGE(m_Ammo, CurWeapon );	// Current weapon and clip
-DECLARE_MESSAGE(m_Ammo, WeaponList);	// new weapon type
-DECLARE_MESSAGE(m_Ammo, AmmoX);			// update known ammo type's count
-DECLARE_MESSAGE(m_Ammo, AmmoPickup);	// flashes an ammo pickup record
-DECLARE_MESSAGE(m_Ammo, WeapPickup);	// flashes a weapon pickup record
-DECLARE_MESSAGE(m_Ammo, HideWeapon);	// hides the weapon, ammo, and crosshair displays temporarily
-DECLARE_MESSAGE(m_Ammo, ItemPickup);
+DECLARE_MESSAGE_PTR(m_Ammo, CurWeapon );	// Current weapon and clip
+DECLARE_MESSAGE_PTR(m_Ammo, WeaponList);	// new weapon type
+DECLARE_MESSAGE_PTR(m_Ammo, AmmoX);			// update known ammo type's count
+DECLARE_MESSAGE_PTR(m_Ammo, AmmoPickup);	// flashes an ammo pickup record
+DECLARE_MESSAGE_PTR(m_Ammo, WeapPickup);	// flashes a weapon pickup record
+DECLARE_MESSAGE_PTR(m_Ammo, HideWeapon);	// hides the weapon, ammo, and crosshair displays temporarily
+DECLARE_MESSAGE_PTR(m_Ammo, ItemPickup);
 
-DECLARE_COMMAND(m_Ammo, Slot1);
-DECLARE_COMMAND(m_Ammo, Slot2);
-DECLARE_COMMAND(m_Ammo, Slot3);
-DECLARE_COMMAND(m_Ammo, Slot4);
-DECLARE_COMMAND(m_Ammo, Slot5);
-DECLARE_COMMAND(m_Ammo, Slot6);
-DECLARE_COMMAND(m_Ammo, Slot7);
-DECLARE_COMMAND(m_Ammo, Slot8);
-DECLARE_COMMAND(m_Ammo, Slot9);
-DECLARE_COMMAND(m_Ammo, Slot10);
-DECLARE_COMMAND(m_Ammo, Close);
-DECLARE_COMMAND(m_Ammo, NextWeapon);
-DECLARE_COMMAND(m_Ammo, PrevWeapon);
+DECLARE_COMMAND_PTR(m_Ammo, Slot1);
+DECLARE_COMMAND_PTR(m_Ammo, Slot2);
+DECLARE_COMMAND_PTR(m_Ammo, Slot3);
+DECLARE_COMMAND_PTR(m_Ammo, Slot4);
+DECLARE_COMMAND_PTR(m_Ammo, Slot5);
+DECLARE_COMMAND_PTR(m_Ammo, Slot6);
+DECLARE_COMMAND_PTR(m_Ammo, Slot7);
+DECLARE_COMMAND_PTR(m_Ammo, Slot8);
+DECLARE_COMMAND_PTR(m_Ammo, Slot9);
+DECLARE_COMMAND_PTR(m_Ammo, Slot10);
+DECLARE_COMMAND_PTR(m_Ammo, Close);
+DECLARE_COMMAND_PTR(m_Ammo, NextWeapon);
+DECLARE_COMMAND_PTR(m_Ammo, PrevWeapon);
 
 // width of ammo fonts
 #define AMMO_SMALL_WIDTH 10
@@ -429,13 +431,13 @@ HLHSPRITE* WeaponsResource :: GetAmmoPicFromWeapon( int iAmmoId, wrect_t& rect )
 
 void WeaponsResource :: SelectSlot( int iSlot, int fAdvance, int iDirection )
 {
-	if ( gHUD.m_Menu.m_fMenuDisplayed && (fAdvance == FALSE) && (iDirection == 1) )
+	if ( gHUD.m_Menu->m_fMenuDisplayed && (fAdvance == FALSE) && (iDirection == 1) )
 	{ // menu is overriding slot use commands
-		gHUD.m_Menu.SelectMenuItem( iSlot + 1 );  // slots are one off the key numbers
+		gHUD.m_Menu->SelectMenuItem( iSlot + 1 );  // slots are one off the key numbers
 		return;
 	}
 
-	if ( iSlot > gHUD.m_Ammo.GetMaxSlot() )
+	if ( iSlot > gHUD.m_Ammo->GetMaxSlot() )
 		return;
 
 	if ( gHUD.m_fPlayerDead || gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL ) )
@@ -625,7 +627,7 @@ int CHudAmmo::MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf )
 
 	UpdateCrosshair();
 
-	m_fFade = FADE_TIME;
+	m_fFade = HUD_FADE_TIME;
 	m_iFlags |= HUD_ACTIVE;
 
 	return 1;
@@ -886,7 +888,7 @@ int CHudAmmo::Draw(float flTime)
 		m_fFade -= (gHUD.m_flTimeDelta * 20);
 		if (m_fFade <= 0)
 			m_fFade = 0;
-		a = MIN_ALPHA + (m_fFade/FADE_TIME) * ALPHA_AMMO_FLASH;
+		a = MIN_ALPHA + (m_fFade/HUD_FADE_TIME) * ALPHA_AMMO_FLASH;
 	}
 	else
 		a = MIN_ALPHA;

--- a/cl_dll/CHudAmmo.h
+++ b/cl_dll/CHudAmmo.h
@@ -1,0 +1,52 @@
+#ifndef CHUDAMMO_H
+#define CHUDAMMO_H
+
+#include "CHudBase.h"
+#include "ammo.h"
+
+class CHudAmmo : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	void Think(void);
+	void Reset(void);
+	int DrawWList(float flTime);
+	void UpdateCrosshair();
+	int MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_WeaponList(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_AmmoX(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_AmmoPickup(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_WeapPickup(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_ItemPickup(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_HideWeapon(const char *pszName, int iSize, void *pbuf);
+
+	int GetMaxSlot(void) { return m_iMaxSlot; }
+	void SlotInput(int iSlot);
+	void _cdecl UserCmd_Slot1(void);
+	void _cdecl UserCmd_Slot2(void);
+	void _cdecl UserCmd_Slot3(void);
+	void _cdecl UserCmd_Slot4(void);
+	void _cdecl UserCmd_Slot5(void);
+	void _cdecl UserCmd_Slot6(void);
+	void _cdecl UserCmd_Slot7(void);
+	void _cdecl UserCmd_Slot8(void);
+	void _cdecl UserCmd_Slot9(void);
+	void _cdecl UserCmd_Slot10(void);
+	void _cdecl UserCmd_Close(void);
+	void _cdecl UserCmd_NextWeapon(void);
+	void _cdecl UserCmd_PrevWeapon(void);
+
+private:
+	float	m_fFade;
+	WEAPON	*m_pWeapon;
+	int		m_fOnTarget;
+	int		m_HUD_bucket0;
+	int		m_HUD_selection;
+	int		m_iMaxSlot;	// There are 5 (0-4) slots by default and they can extend to 6. This will be used to draw additional weapon bucket(s) on a hud.
+
+	cvar_t	*m_pCvarHudWeapon;
+};
+
+#endif

--- a/cl_dll/CHudAmmoSecondary.cpp
+++ b/cl_dll/CHudAmmoSecondary.cpp
@@ -18,14 +18,15 @@
 // implementation of CHudAmmoSecondary class
 //
 
+#include "CHudAmmoSecondary.h"
 #include "hud.h"
 #include "cl_util.h"
 #include <string.h>
 #include <stdio.h>
 #include "parsemsg.h"
 
-DECLARE_MESSAGE( m_AmmoSecondary, SecAmmoVal );
-DECLARE_MESSAGE( m_AmmoSecondary, SecAmmoIcon );
+DECLARE_MESSAGE_PTR( m_AmmoSecondary, SecAmmoVal );
+DECLARE_MESSAGE_PTR( m_AmmoSecondary, SecAmmoIcon );
 
 int CHudAmmoSecondary :: Init( void )
 {
@@ -70,7 +71,7 @@ int CHudAmmoSecondary :: Draw(float flTime)
 		m_fFade -= (gHUD.m_flTimeDelta * 20);
 		if (m_fFade <= 0)
 			m_fFade = 0;
-		a = MIN_ALPHA + (m_fFade/FADE_TIME) * ALPHA_AMMO_FLASH;
+		a = MIN_ALPHA + (m_fFade/HUD_FADE_TIME) * ALPHA_AMMO_FLASH;
 	}
 	else
 		a = MIN_ALPHA;
@@ -164,7 +165,7 @@ int CHudAmmoSecondary :: MsgFunc_SecAmmoVal( const char *pszName, int iSize, voi
 	}
 
 	// make the icons light up
-	m_fFade = FADE_TIME;
+	m_fFade = HUD_FADE_TIME;
 
 	return 1;
 }

--- a/cl_dll/CHudAmmoSecondary.h
+++ b/cl_dll/CHudAmmoSecondary.h
@@ -1,0 +1,28 @@
+#ifndef CHUDAMMOSECONDARY_H
+#define CHUDAMMOSECONDARY_H
+
+#include "CHudBase.h"
+#include "ammo.h"
+
+class CHudAmmoSecondary : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	void Reset(void);
+	int Draw(float flTime);
+
+	int MsgFunc_SecAmmoVal(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_SecAmmoIcon(const char *pszName, int iSize, void *pbuf);
+
+private:
+	enum {
+		MAX_SEC_AMMO_VALUES = 4
+	};
+
+	int m_HUD_ammoicon; // sprite indices
+	int m_iAmmoAmounts[MAX_SEC_AMMO_VALUES];
+	float m_fFade;
+};
+
+#endif

--- a/cl_dll/CHudBase.cpp
+++ b/cl_dll/CHudBase.cpp
@@ -1,0 +1,28 @@
+#include "CHudBase.h"
+
+int CHudBase::Init(void)
+{
+	return 0;
+}
+
+int CHudBase::VidInit(void)
+{
+	return 0;
+}
+
+int CHudBase::Draw(float flTime)
+{
+	return 0;
+}
+
+void CHudBase::Think(void)
+{
+}
+
+void CHudBase::Reset(void)
+{
+}
+
+void CHudBase::InitHUDData(void)
+{
+}

--- a/cl_dll/CHudBase.h
+++ b/cl_dll/CHudBase.h
@@ -61,7 +61,7 @@ public:
 	virtual void Think(void);
 	virtual void Reset(void);
 	virtual void InitHUDData(void);		// called every time a server is connected to
-
+	bool m_isDeletable = false;
 };
 
 #endif

--- a/cl_dll/CHudBase.h
+++ b/cl_dll/CHudBase.h
@@ -1,0 +1,67 @@
+#ifndef CHUDBASE_H
+#define CHUDBASE_H
+
+#include "cl_dll.h"
+#include "wrect.h"
+#include "cvardef.h"
+
+#define RGB_YELLOWISH	0x00FFA000 //255,160,0
+#define RGB_REDISH		0x00FF1010 //255,160,0
+#define RGB_GREENISH	0x0000A000 //0,160,0
+
+#define DHN_DRAWZERO	1
+#define DHN_2DIGITS		2
+#define DHN_3DIGITS		4
+#define MIN_ALPHA		100
+#define ALPHA_AMMO_FLASH	100
+#define ALPHA_AMMO_MAX		128
+#define ALPHA_POINTS_FLASH	128
+#define ALPHA_POINTS_MAX	155
+
+#define HUDELEM_ACTIVE	1
+
+#define HUD_ACTIVE			1
+#define HUD_INTERMISSION	2
+
+#define MAX_HUD_STRING			80
+#define MAX_MOTD_LENGTH			1536
+#define MAX_STEAMID				32	// 0:0:4294967295, STEAM_ID_PENDING
+#define MAX_MAP_NAME			64
+
+#define ADJUST_MENU		-5	// space correction between text lines in hud menu in pixels
+#define ADJUST_MESSAGE	0	// space correction between text lines in hud messages in pixels
+
+#define HUD_FADE_TIME 100
+
+union RGBA {
+	struct { unsigned char r, g, b, a; };
+	unsigned int c;
+
+	RGBA() { c = 0; }
+	RGBA(unsigned int value) { c = value; }
+	void Set(unsigned char r1, unsigned char g1, unsigned char b1) { r = r1; g = g1; b = b1; a = 255; }
+};
+
+typedef struct {
+	int x, y;
+} POSITION;
+
+typedef struct cvar_s cvar_t;
+
+class CHudBase
+{
+public:
+	POSITION  m_pos;
+	int   m_type;
+	int	  m_iFlags; // active, moving, 
+	virtual		~CHudBase() {}
+	virtual int Init(void);
+	virtual int VidInit(void);
+	virtual int Draw(float flTime);
+	virtual void Think(void);
+	virtual void Reset(void);
+	virtual void InitHUDData(void);		// called every time a server is connected to
+
+};
+
+#endif

--- a/cl_dll/CHudBattery.cpp
+++ b/cl_dll/CHudBattery.cpp
@@ -18,14 +18,14 @@
 // implementation of CHudBattery class
 //
 
+#include <string.h>
+#include <stdio.h>
+#include "CHudBattery.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
 
-#include <string.h>
-#include <stdio.h>
-
-DECLARE_MESSAGE(m_Battery, Battery)
+DECLARE_MESSAGE_PTR(m_Battery, Battery)
 
 int CHudBattery::Init(void)
 {
@@ -63,7 +63,7 @@ int CHudBattery:: MsgFunc_Battery(const char *pszName,  int iSize, void *pbuf )
 
 	if (battery != m_iBat)
 	{
-		m_fFade = FADE_TIME;
+		m_fFade = HUD_FADE_TIME;
 		m_iBat = battery;
 	}
 
@@ -93,7 +93,7 @@ int CHudBattery::Draw(float flTime)
 		m_fFade -= (gHUD.m_flTimeDelta * 20);
 		if (m_fFade <= 0)
 			m_fFade = 0;
-		a = MIN_ALPHA + (m_fFade/FADE_TIME) * ALPHA_POINTS_FLASH;
+		a = MIN_ALPHA + (m_fFade/HUD_FADE_TIME) * ALPHA_POINTS_FLASH;
 	}
 	else
 		a = MIN_ALPHA;

--- a/cl_dll/CHudBattery.h
+++ b/cl_dll/CHudBattery.h
@@ -1,0 +1,24 @@
+#ifndef CHUDBATTERY_H
+#define CHUDBATTERY_H
+
+#include "CHudBase.h"
+
+class CHudBattery : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_Battery(const char *pszName, int iSize, void *pbuf);
+
+private:
+	HLHSPRITE m_hSprite1;
+	HLHSPRITE m_hSprite2;
+	wrect_t *m_prc1;
+	wrect_t *m_prc2;
+	int	  m_iBat;
+	float m_fFade;
+	int	  m_iHeight;		// width of the battery innards
+};
+
+#endif

--- a/cl_dll/CHudDeathNotice.cpp
+++ b/cl_dll/CHudDeathNotice.cpp
@@ -15,16 +15,17 @@
 //
 // death notice
 //
+
+#include <stdio.h>
+#include <string.h>
+#include "CHudDeathNotice.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
-
-#include <string.h>
-#include <stdio.h>
-
 #include "vgui_TeamFortressViewport.h"
+#include "CHudSpectator.h"
 
-DECLARE_MESSAGE( m_DeathNotice, DeathMsg );
+DECLARE_MESSAGE_PTR( m_DeathNotice, DeathMsg );
 
 struct DeathNoticeItem {
 	char szKiller[MAX_PLAYER_NAME];
@@ -148,7 +149,7 @@ int CHudDeathNotice :: MsgFunc_DeathMsg( const char *pszName, int iSize, void *p
 	if (gViewPort)
 		gViewPort->DeathMsg( killer, victim );
 
-	gHUD.m_Spectator.DeathMessage(victim);
+	gHUD.m_Spectator->DeathMessage(victim);
 
 	int i;
 	for ( i = 0; i < MAX_DEATHNOTICES; i++ )

--- a/cl_dll/CHudDeathNotice.h
+++ b/cl_dll/CHudDeathNotice.h
@@ -1,0 +1,19 @@
+#ifndef CHUDDEATHNOTICE_H
+#define CHUDDEATHNOTICE_H
+
+#include "CHudBase.h"
+
+class CHudDeathNotice : public CHudBase
+{
+public:
+	int Init(void);
+	void InitHUDData(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_DeathMsg(const char *pszName, int iSize, void *pbuf);
+
+private:
+	int m_HUD_d_skull;  // sprite index of skull icon
+};
+
+#endif

--- a/cl_dll/CHudFlashlight.cpp
+++ b/cl_dll/CHudFlashlight.cpp
@@ -18,17 +18,15 @@
 // implementation of CHudFlashlight class
 //
 
+#include <stdio.h>
+#include <string.h>
+#include "CHudFlashlight.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
 
-#include <string.h>
-#include <stdio.h>
-
-
-
-DECLARE_MESSAGE(m_Flash, FlashBat)
-DECLARE_MESSAGE(m_Flash, Flashlight)
+DECLARE_MESSAGE_PTR(m_Flash, FlashBat)
+DECLARE_MESSAGE_PTR(m_Flash, Flashlight)
 
 #define BAT_NAME "sprites/%d_Flashlight.spr"
 

--- a/cl_dll/CHudFlashlight.h
+++ b/cl_dll/CHudFlashlight.h
@@ -1,0 +1,30 @@
+#ifndef CHUDFLASHLIGHT_H
+#define CHUDFLASHLIGHT_H
+
+#include "CHudBase.h"
+
+class CHudFlashlight : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	void Reset(void);
+	int MsgFunc_Flashlight(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_FlashBat(const char *pszName, int iSize, void *pbuf);
+
+private:
+	HLHSPRITE m_hSprite1;
+	HLHSPRITE m_hSprite2;
+	HLHSPRITE m_hBeam;
+	wrect_t *m_prc1;
+	wrect_t *m_prc2;
+	wrect_t *m_prcBeam;
+	float m_flBat;
+	int	  m_iBat;
+	int	  m_fOn;
+	float m_fFade;
+	int	  m_iWidth;		// width of the battery innards
+};
+
+#endif

--- a/cl_dll/CHudGeiger.cpp
+++ b/cl_dll/CHudGeiger.cpp
@@ -17,16 +17,15 @@
 //
 // implementation of CHudAmmo class
 //
-
-#include "hud.h"
-#include "cl_util.h"
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <stdio.h>
-
+#include "CHudGeiger.h"
+#include "hud.h"
+#include "cl_util.h"
 #include "parsemsg.h"
 
-DECLARE_MESSAGE(m_Geiger, Geiger )
+DECLARE_MESSAGE_PTR(m_Geiger, Geiger )
 
 int CHudGeiger::Init(void)
 {

--- a/cl_dll/CHudGeiger.h
+++ b/cl_dll/CHudGeiger.h
@@ -1,0 +1,19 @@
+#ifndef CHUDGEIGER_H
+#define CHUDGEIGER_H
+
+#include "CHudBase.h"
+
+class CHudGeiger : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_Geiger(const char *pszName, int iSize, void *pbuf);
+
+private:
+	int m_iGeigerRange;
+
+};
+
+#endif

--- a/cl_dll/CHudHealth.cpp
+++ b/cl_dll/CHudHealth.cpp
@@ -18,18 +18,19 @@
 // implementation of CHudHealth class
 //
 
-#include "STDIO.H"
-#include "STDLIB.H"
-#include "MATH.H"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
 
+#include "CHudHealth.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
-#include <string.h>
 
 
-DECLARE_MESSAGE(m_Health, Health )
-DECLARE_MESSAGE(m_Health, Damage )
+DECLARE_MESSAGE_PTR(m_Health, Health )
+DECLARE_MESSAGE_PTR(m_Health, Damage )
 
 #define PAIN_NAME "sprites/%d_pain.spr"
 #define DAMAGE_NAME "sprites/%d_dmg.spr"
@@ -40,9 +41,9 @@ int giDmgFlags[NUM_DMG_TYPES] =
 {
 	DMG_POISON,
 	DMG_ACID,
-	DMG_FREEZE|DMG_SLOWFREEZE,
+	DMG_FREEZE | DMG_SLOWFREEZE,
 	DMG_DROWN,
-	DMG_BURN|DMG_SLOWBURN,
+	DMG_BURN | DMG_SLOWBURN,
 	DMG_NERVEGAS, 
 	DMG_RADIATION,
 	DMG_SHOCK,
@@ -110,7 +111,7 @@ int CHudHealth:: MsgFunc_Health(const char *pszName,  int iSize, void *pbuf )
 	// Only update the fade if we've changed health
 	if (x != m_iHealth)
 	{
-		m_fFade = FADE_TIME;
+		m_fFade = HUD_FADE_TIME;
 		m_iHealth = x;
 	}
 
@@ -190,7 +191,7 @@ int CHudHealth::Draw(float flTime)
 		m_fFade -= (gHUD.m_flTimeDelta * 20);
 		if (m_fFade <= 0)
 			m_fFade = 0;
-		a = MIN_ALPHA + (m_fFade/FADE_TIME) * ALPHA_POINTS_FLASH;
+		a = MIN_ALPHA + (m_fFade/HUD_FADE_TIME) * ALPHA_POINTS_FLASH;
 	}
 	else
 		a = MIN_ALPHA;
@@ -201,7 +202,7 @@ int CHudHealth::Draw(float flTime)
 	health = clamp(health, 0, 999);
 	if (m_iHealth != health && health > 255)
 	{
-		m_fFade = FADE_TIME;
+		m_fFade = HUD_FADE_TIME;
 		m_iHealth = health;
 	}
 

--- a/cl_dll/CHudHealth.h
+++ b/cl_dll/CHudHealth.h
@@ -12,6 +12,10 @@
 *   without written permission from Valve LLC.
 *
 ****/
+#ifndef CHUDHEALTH_H
+#define CHUDHEALTH_H
+
+#include "CHudBase.h"
 
 #define DMG_IMAGE_LIFE		2	// seconds that image is up
 
@@ -72,9 +76,8 @@
 #define DMG_IGNOREARMOR		(1 << 27)	// Damage ignores target's armor
 #define DMG_AIMED			(1 << 28)   // Does Hit location damage
 #define DMG_WALLPIERCING	(1 << 29)	// Blast Damages ents through walls
-
-#define DMG_CALTROP				(1<<30)
-#define DMG_HALLUC				(1<<31)
+#define DMG_CALTROP			(1 << 30)
+#define DMG_HALLUC			(1 << 31)
 
 // TF Healing Additions for TakeHealth
 #define DMG_IGNORE_MAXHEALTH	DMG_IGNITE
@@ -125,3 +128,5 @@ private:
 	void CalcDamageDirection(vec3_t vecFrom);
 	void UpdateTiles(float fTime, long bits);
 };	
+
+#endif

--- a/cl_dll/CHudMenu.cpp
+++ b/cl_dll/CHudMenu.cpp
@@ -17,14 +17,15 @@
 //
 // generic menu handler
 //
+
+#include <stdio.h>
+#include <string.h>
+#include "CHudMenu.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
-
-#include <string.h>
-#include <stdio.h>
-
 #include "vgui_TeamFortressViewport.h"
+#include "CHudTextMessage.h"
 
 #define MAX_MENU_STRING 512
 char g_szMenuString[MAX_MENU_STRING];
@@ -32,7 +33,7 @@ char g_szPrelocalisedMenuString[MAX_MENU_STRING];
 
 int KB_ConvertString( char *in, char **ppout );
 
-DECLARE_MESSAGE( m_Menu, ShowMenu );
+DECLARE_MESSAGE_PTR( m_Menu, ShowMenu );
 
 int CHudMenu :: Init( void )
 {
@@ -165,7 +166,7 @@ int CHudMenu :: MsgFunc_ShowMenu( const char *pszName, int iSize, void *pbuf )
 
 		if ( !NeedMore )
 		{  // we have the whole string, so we can localise it now
-			strcpy( g_szMenuString, gHUD.m_TextMessage.BufferedLocaliseTextString( g_szPrelocalisedMenuString ) );
+			strcpy( g_szMenuString, gHUD.m_TextMessage->BufferedLocaliseTextString( g_szPrelocalisedMenuString ) );
 
 			// Swap in characters
 			if ( KB_ConvertString( g_szMenuString, &temp ) )

--- a/cl_dll/CHudMenu.h
+++ b/cl_dll/CHudMenu.h
@@ -1,0 +1,24 @@
+#ifndef CHUDMENU
+#define CHUDMENU
+
+#include "CHudBase.h"
+
+class CHudMenu : public CHudBase
+{
+public:
+	int Init(void);
+	void InitHUDData(void);
+	int VidInit(void);
+	void Reset(void);
+	int Draw(float flTime);
+	int MsgFunc_ShowMenu(const char *pszName, int iSize, void *pbuf);
+
+	void SelectMenuItem(int menu_item);
+
+	int m_fMenuDisplayed;
+	int m_bitsValidSlots;
+	float m_flShutoffTime;
+	int m_fWaitingForMore;
+};
+
+#endif

--- a/cl_dll/CHudMessage.cpp
+++ b/cl_dll/CHudMessage.cpp
@@ -17,16 +17,17 @@
 //
 // implementation of CHudMessage class
 //
-
+#include <stdio.h>
+#include <string.h>
+#include <windows.h>
+#include "CHudMessage.h"
 #include "hud.h"
 #include "cl_util.h"
-#include <string.h>
-#include <stdio.h>
-#include <windows.h>
 #include "parsemsg.h"
+#include "CHudTimer.h"
 
-DECLARE_MESSAGE( m_Message, HudText )
-DECLARE_MESSAGE( m_Message, GameTitle )
+DECLARE_MESSAGE_PTR( m_Message, HudText )
+DECLARE_MESSAGE_PTR( m_Message, GameTitle )
 
 // 1 Global client_textmessage_t for custom messages that aren't in the titles.txt
 #define MAX_MESSAGE_TEXT_LENGTH	1024
@@ -379,7 +380,7 @@ int CHudMessage::Draw( float fTime )
 		pMessage = m_pMessages[i];
 
 		// Filter out MiniAG timer that passed before we detected server AG version
-		if (gHUD.m_Timer.GetAgVersion() == CHudTimer::SV_AG_MINI && (
+		if (gHUD.m_Timer->GetAgVersion() == CHudTimer::SV_AG_MINI && (
 			fabs(pMessage->y - 0.01) < 0.0002f && fabs(pMessage->x - 0.5) < 0.0002f ||	// Original MiniAG coordinates
 			fabs(pMessage->y - 0.01) < 0.0002f && fabs(pMessage->x + 1) < 0.0002f		// Russian Crossfire MiniAG coordinates
 			))
@@ -469,7 +470,7 @@ void CHudMessage::MessageAdd( const char *pName, float time )
 		}
 
 		// Filter out MiniAG timer
-		if (gHUD.m_Timer.GetAgVersion() == CHudTimer::SV_AG_MINI && (
+		if (gHUD.m_Timer->GetAgVersion() == CHudTimer::SV_AG_MINI && (
 			fabs(tempMessage->y - 0.01) < 0.0002f && fabs(tempMessage->x - 0.5) < 0.0002f ||	// Original MiniAG coordinates
 			fabs(tempMessage->y - 0.01) < 0.0002f && fabs(tempMessage->x + 1) < 0.0002f			// Russian Crossfire MiniAG coordinates
 			))

--- a/cl_dll/CHudMessage.h
+++ b/cl_dll/CHudMessage.h
@@ -1,0 +1,55 @@
+#ifndef CHUDMESSAGE_H
+#define CHUDMESSAGE_H
+
+#include "CHudBase.h"
+
+const int maxHUDMessages = 16;
+struct message_parms_t
+{
+	client_textmessage_t	*pMessage;
+	float	time;
+	int x, y;
+	int	totalWidth, totalHeight;
+	int width;
+	int lines;
+	int lineLength;
+	int length;
+	int r, g, b;
+	int currentChar;
+	int fadeBlend;
+	float charTime;
+	float fadeTime;
+};
+
+class CHudMessage : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_HudText(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_GameTitle(const char *pszName, int iSize, void *pbuf);
+
+	float FadeBlend(float fadein, float fadeout, float hold, float localTime);
+	int	XPosition(float x, int width, int lineWidth);
+	int YPosition(float y, int height);
+
+	void MessageAdd(const char *pName, float time);
+	void MessageAdd(client_textmessage_t * newMessage);
+	void MessageDrawScan(client_textmessage_t *pMessage, float time);
+	void MessageScanStart(void);
+	void MessageScanNextChar(void);
+	void Reset(void);
+
+private:
+	client_textmessage_t * m_pMessages[maxHUDMessages];
+	float						m_startTime[maxHUDMessages];
+	message_parms_t				m_parms;
+	float						m_gameTitleTime;
+	client_textmessage_t		*m_pGameTitle;
+
+	int m_HUD_title_life;
+	int m_HUD_title_half;
+};
+
+#endif

--- a/cl_dll/CHudSayText.cpp
+++ b/cl_dll/CHudSayText.cpp
@@ -23,6 +23,7 @@
 #include <time.h>
 #include <windows.h>
 
+#include "CHudSayText.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
@@ -45,7 +46,7 @@ static float flScrollTime = 0;  // the time at which the lines next scroll up
 static int Y_START = 0;
 static int line_height = 0;
 
-DECLARE_MESSAGE( m_SayText, SayText );
+DECLARE_MESSAGE_PTR( m_SayText, SayText );
 
 int CHudSayText :: Init( void )
 {

--- a/cl_dll/CHudSayText.h
+++ b/cl_dll/CHudSayText.h
@@ -1,0 +1,24 @@
+#ifndef CHUDSAYTEXT_H
+#define CHUDSAYTEXT_H
+
+#include "CHudBase.h"
+
+class CHudSayText : public CHudBase
+{
+public:
+	int Init(void);
+	void InitHUDData(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_SayText(const char *pszName, int iSize, void *pbuf);
+	void SayTextPrint(const char *pszBuf, int iBufSize, int clientIndex = -1);
+	void EnsureTextFitsInOneLineAndWrapIfHaveTo(int line);
+	friend class CHudSpectator;
+
+private:
+	struct cvar_s *	m_HUD_saytext;
+	struct cvar_s *	m_HUD_saytext_time;
+	cvar_t	*m_pCvarConSayColor;
+};
+
+#endif

--- a/cl_dll/CHudScores.cpp
+++ b/cl_dll/CHudScores.cpp
@@ -18,6 +18,7 @@
 // implementation of CHudScores class
 //
 
+#include "CHudScores.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "vgui_TeamFortressViewport.h"

--- a/cl_dll/CHudScores.h
+++ b/cl_dll/CHudScores.h
@@ -1,0 +1,28 @@
+#ifndef CHUDSCORES_H
+#define CHUDSCORES_H
+
+#include "CHudBase.h"
+
+struct HudScoresData
+{
+	char szScore[64];
+	int r, g, b;
+};
+
+class CHudScores : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+
+private:
+	HudScoresData m_ScoresData[MAX_PLAYERS] = {};
+	int m_iLines = 0;
+	int m_iOverLay = 0;
+	float m_flScoreBoardLastUpdated = 0;
+	cvar_t* m_pCvarHudScores = nullptr;
+	cvar_t* m_pCvarHudScoresPos = nullptr;
+};
+
+#endif

--- a/cl_dll/CHudSpectator.cpp
+++ b/cl_dll/CHudSpectator.cpp
@@ -5,6 +5,7 @@
 // $NoKeywords: $
 //=============================================================================
 
+#include "CHudSpectator.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "cl_entity.h"
@@ -27,7 +28,11 @@
 #include "screenfade.h"
 
 #include "svc_messages.h"
-
+#include "CHudTextMessage.h"
+#include "CHudSayText.h"
+#include "CHudMessage.h"
+#include "CHudTimer.h"
+#include "CHudAmmo.h"
 
 #pragma warning(disable: 4244)
 
@@ -57,9 +62,9 @@ void SpectatorMode(void)
 
 	// SetModes() will decide if command is executed on server or local
 	if ( gEngfuncs.Cmd_Argc() == 2 )
-		gHUD.m_Spectator.SetModes( atoi( gEngfuncs.Cmd_Argv(1) ), -1 );
+		gHUD.m_Spectator->SetModes( atoi( gEngfuncs.Cmd_Argv(1) ), -1 );
 	else if ( gEngfuncs.Cmd_Argc() == 3 )
-		gHUD.m_Spectator.SetModes( atoi( gEngfuncs.Cmd_Argv(1) ), atoi( gEngfuncs.Cmd_Argv(2) )  );	
+		gHUD.m_Spectator->SetModes( atoi( gEngfuncs.Cmd_Argv(1) ), atoi( gEngfuncs.Cmd_Argv(2) )  );	
 }
 
 void SpectatorSpray(void)
@@ -141,7 +146,7 @@ int CHudSpectator::Init()
 	m_flNextObserverInput = 0.0f;
 	m_zoomDelta	= 0.0f;
 	m_moveDelta = 0.0f;
-	m_chatEnabled = (gHUD.m_SayText.m_HUD_saytext->value!=0);
+	m_chatEnabled = (gHUD.m_SayText->m_HUD_saytext->value!=0);
 	iJumpSpectator	= 0;
 
 	memset( &m_OverviewData, 0, sizeof(m_OverviewData));
@@ -540,7 +545,7 @@ void CHudSpectator::DirectorMessage( int iSize, void *pbuf )
 								msg->pMessage = m_HUDMessageText[m_lastHudMessage];
 								msg->pName	  = "HUD_MESSAGE";
 
-								gHUD.m_Message.MessageAdd( msg );
+								gHUD.m_Message->MessageAdd( msg );
 
 								m_lastHudMessage++;
 								m_lastHudMessage %= MAX_SPEC_HUD_MESSAGES;
@@ -805,7 +810,7 @@ void CHudSpectator::SetModes(int iNewMainMode, int iNewInsetMode)
 		{
 			char cmdstring[32];
 			// forward command to server
-			if (gHUD.m_Timer.GetAgVersion() == CHudTimer::SV_AG_MINI || gHUD.m_Timer.GetAgVersion() == CHudTimer::SV_AG_FULL)
+			if (gHUD.m_Timer->GetAgVersion() == CHudTimer::SV_AG_MINI || gHUD.m_Timer->GetAgVersion() == CHudTimer::SV_AG_FULL)
 				sprintf(cmdstring,"spec_mode %i", iNewMainMode);
 			else
 				sprintf(cmdstring,"specmode %i", iNewMainMode);
@@ -876,7 +881,7 @@ void CHudSpectator::SetModes(int iNewMainMode, int iNewInsetMode)
 		char string[128];
 		sprintf(string, "#Spec_Mode%d", g_iUser1 );
 		sprintf(string, "%c%s", HUD_PRINTCENTER, CHudTextMessage::BufferedLocaliseTextString( string ));
-		gHUD.m_TextMessage.MsgFunc_TextMsg(NULL, strlen(string)+1, string );
+		gHUD.m_TextMessage->MsgFunc_TextMsg(NULL, strlen(string)+1, string );
 	}
 
 	gViewPort->UpdateSpectatorPanel();
@@ -1508,10 +1513,10 @@ void CHudSpectator::CheckSettings()
 		m_pip->value = INSET_OFF;
 
 	// check chat mode
-	if ( m_chatEnabled != (gHUD.m_SayText.m_HUD_saytext->value!=0) )
+	if ( m_chatEnabled != (gHUD.m_SayText->m_HUD_saytext->value!=0) )
 	{
 		// hud_saytext changed
-		m_chatEnabled = (gHUD.m_SayText.m_HUD_saytext->value!=0);
+		m_chatEnabled = (gHUD.m_SayText->m_HUD_saytext->value!=0);
 
 		if ( gEngfuncs.IsSpectateOnly() )
 		{
@@ -1544,7 +1549,7 @@ void CHudSpectator::CheckSettings()
 		// Show crosshair only for First Person mode
 		if (g_iUser1 == OBS_IN_EYE)
 		{
-			gHUD.m_Ammo.UpdateCrosshair();
+			gHUD.m_Ammo->UpdateCrosshair();
 		}
 		else
 		{

--- a/cl_dll/CHudSpectator.h
+++ b/cl_dll/CHudSpectator.h
@@ -5,13 +5,11 @@
 // $NoKeywords: $
 //=============================================================================
 
-#ifndef SPECTATOR_H
-#define SPECTATOR_H
-#pragma once
+#ifndef CHUDSPECTATOR_H
+#define CHUDSPECTATOR_H
 
+#include "CHudBase.h"
 #include "cl_entity.h"
-
-
 
 #define INSET_OFF				0
 #define	INSET_CHASE_FREE		1

--- a/cl_dll/CHudStatusBar.cpp
+++ b/cl_dll/CHudStatusBar.cpp
@@ -19,15 +19,16 @@
 // runs across bottom of screen
 //
 
+#include <stdio.h>
+#include <string.h>
+#include "CHudStatusBar.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
+#include "CHudTextMessage.h"
 
-#include <string.h>
-#include <stdio.h>
-
-DECLARE_MESSAGE( m_StatusBar, StatusText );
-DECLARE_MESSAGE( m_StatusBar, StatusValue );
+DECLARE_MESSAGE_PTR( m_StatusBar, StatusText );
+DECLARE_MESSAGE_PTR( m_StatusBar, StatusValue );
 
 #define STATUSBAR_ID_LINE		1
 
@@ -74,7 +75,7 @@ void CHudStatusBar :: ParseStatusString( int line_num )
 	// localise string first
 	char szBuffer[MAX_STATUSTEXT_LENGTH];
 	memset( szBuffer, 0, sizeof szBuffer );
-	gHUD.m_TextMessage.LocaliseTextString( m_szStatusText[line_num], szBuffer, MAX_STATUSTEXT_LENGTH );
+	gHUD.m_TextMessage->LocaliseTextString( m_szStatusText[line_num], szBuffer, MAX_STATUSTEXT_LENGTH );
 
 	// parse m_szStatusText & m_iStatusValues into m_szStatusBar
 	memset( m_szStatusBar[line_num], 0, MAX_STATUSTEXT_LENGTH );

--- a/cl_dll/CHudStatusBar.h
+++ b/cl_dll/CHudStatusBar.h
@@ -1,0 +1,35 @@
+#ifndef CHUDSTATUSBAR_H
+#define CHUDSTATUSBAR_H
+
+#include "CHudBase.h"
+
+class CHudStatusBar : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	void Reset(void);
+	void ParseStatusString(int line_num);
+
+	int MsgFunc_StatusText(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_StatusValue(const char *pszName, int iSize, void *pbuf);
+
+protected:
+	enum {
+		MAX_STATUSTEXT_LENGTH = 128,
+		MAX_STATUSBAR_VALUES = 8,
+		MAX_STATUSBAR_LINES = 2,
+	};
+
+	char m_szStatusText[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];  // a text string describing how the status bar is to be drawn
+	char m_szStatusBar[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];	// the constructed bar that is drawn
+	int m_iStatusValues[MAX_STATUSBAR_VALUES];  // an array of values for use in the status bar
+
+	int m_bReparseString; // set to TRUE whenever the m_szStatusBar needs to be recalculated
+
+						  // an array of colors...one color for each line
+	float *m_pflNameColors[MAX_STATUSBAR_LINES];
+};
+
+#endif

--- a/cl_dll/CHudStatusIcons.cpp
+++ b/cl_dll/CHudStatusIcons.cpp
@@ -15,17 +15,18 @@
 //
 // status_icons.cpp
 //
+#include <stdio.h>
+#include <string.h>
+#include "CHudStatusIcons.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "const.h"
 #include "entity_state.h"
 #include "cl_entity.h"
-#include <string.h>
-#include <stdio.h>
 #include "parsemsg.h"
 #include "event_api.h"
 
-DECLARE_MESSAGE( m_StatusIcons, StatusIcon );
+DECLARE_MESSAGE_PTR( m_StatusIcons, StatusIcon );
 
 int CHudStatusIcons::Init( void )
 {

--- a/cl_dll/CHudStatusIcons.h
+++ b/cl_dll/CHudStatusIcons.h
@@ -1,0 +1,43 @@
+#ifndef CHUDSTATUSICONS_H
+#define CHUDSTATUSICONS_H
+
+#include "CHudBase.h"
+
+#define MAX_SPRITE_NAME_LENGTH		24
+#define RESERVE_SPRITES_FOR_WEAPONS	32
+
+class CHudStatusIcons : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	void Reset(void);
+	int Draw(float flTime);
+	int MsgFunc_StatusIcon(const char *pszName, int iSize, void *pbuf);
+
+	enum {
+		MAX_ICONSPRITENAME_LENGTH = MAX_SPRITE_NAME_LENGTH,
+		MAX_ICONSPRITES = 4,
+	};
+
+
+	//had to make these public so CHud could access them (to enable concussion icon)
+	//could use a friend declaration instead...
+	void EnableIcon(char *pszIconName, unsigned char red, unsigned char green, unsigned char blue);
+	void DisableIcon(char *pszIconName);
+
+private:
+
+	typedef struct
+	{
+		char szSpriteName[MAX_ICONSPRITENAME_LENGTH];
+		HLHSPRITE spr;
+		wrect_t rc;
+		unsigned char r, g, b;
+	} icon_sprite_t;
+
+	icon_sprite_t m_IconList[MAX_ICONSPRITES];
+
+};
+
+#endif

--- a/cl_dll/CHudTextMessage.cpp
+++ b/cl_dll/CHudTextMessage.cpp
@@ -22,13 +22,14 @@
 
 #include <string.h>
 #include <stdio.h>
-
+#include "CHudTextMessage.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
 #include "vgui_TeamFortressViewport.h"
+#include "CHudSayText.h"
 
-DECLARE_MESSAGE( m_TextMessage, TextMsg );
+DECLARE_MESSAGE_PTR( m_TextMessage, TextMsg );
 
 int CHudTextMessage::Init(void)
 {
@@ -231,7 +232,7 @@ int CHudTextMessage::MsgFunc_TextMsg( const char *pszName, int iSize, void *pbuf
 		ConsolePrint(szBuf[0]);
 		break;
 	case HUD_PRINTTALK:
-		gHUD.m_SayText.SayTextPrint(szBuf[0], 128);
+		gHUD.m_SayText->SayTextPrint(szBuf[0], 128);
 		break;
 	case HUD_PRINTCENTER:
 		if (gViewPort && gViewPort->AllowedToPrintText() == FALSE)

--- a/cl_dll/CHudTextMessage.h
+++ b/cl_dll/CHudTextMessage.h
@@ -1,0 +1,16 @@
+#ifndef CHUDTEXTMESSAGE_H
+#define CHUDTEXTMESSAGE_H
+
+#include "CHudBase.h"
+
+class CHudTextMessage : public CHudBase
+{
+public:
+	int Init(void);
+	static char *LocaliseTextString(const char *msg, char *dst_buffer, int buffer_size);
+	static char *BufferedLocaliseTextString(const char *msg);
+	char *LookupString(const char *msg_name, int *msg_dest = NULL);
+	int MsgFunc_TextMsg(const char *pszName, int iSize, void *pbuf);
+};
+
+#endif

--- a/cl_dll/CHudTimer.cpp
+++ b/cl_dll/CHudTimer.cpp
@@ -4,7 +4,7 @@
 *
 ****/
 //
-// Hud_timer.cpp
+// CHudTimer.cpp
 //
 // implementation of CHudTimer class
 //
@@ -12,6 +12,7 @@
 #include <windows.h>
 #include <time.h>
 
+#include "CHudTimer.h"
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
@@ -37,12 +38,12 @@ enum RulesRequestStatus
 	SOCKET_IDLE = 1,
 	SOCKET_AWAITING_CODE = 2,
 	SOCKET_AWAITING_ANSWER = 3,
-} g_eRulesRequestStatus = SOCKET_NONE;
-
+};
+RulesRequestStatus g_eRulesRequestStatus = SOCKET_NONE;
 SOCKET g_timerSocket = NULL;	// We will declare socket here to not include winsocks in hud.h
 
 
-DECLARE_MESSAGE(m_Timer, Timer)
+DECLARE_MESSAGE_PTR(m_Timer, Timer)
 
 int CHudTimer::Init(void)
 {
@@ -509,6 +510,27 @@ void CHudTimer::CustomTimerCommand(void)
 	m_bCustomTimerNeedSound[number] = true;
 
 	m_bNeedWriteCustomTimer = true;
+}
+
+int CHudTimer::GetAgVersion()
+{
+	return m_eAgVersion;
+}
+
+float CHudTimer::GetHudNextmap()
+{
+	return m_pCvarHudNextmap->value;
+}
+
+const char *CHudTimer::GetNextmap()
+{
+	return m_szNextmap;
+}
+
+void CHudTimer::SetNextmap(const char *nextmap)
+{
+	strncpy(m_szNextmap, nextmap, HLARRAYSIZE(m_szNextmap) - 1);
+	m_szNextmap[HLARRAYSIZE(m_szNextmap) - 1] = 0;
 }
 
 int CHudTimer::Draw(float fTime)

--- a/cl_dll/CHudTimer.h
+++ b/cl_dll/CHudTimer.h
@@ -1,0 +1,74 @@
+#ifndef CHUDTIMER_H
+#define CHUDTIMER_H
+
+#include "CHudBase.h"
+
+class CHudTimer : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	void Think(void);
+	int Draw(float flTime);
+
+	int MsgFunc_Timer(const char *pszName, int iSize, void *pbuf);
+
+	void DoResync(void);
+	void ReadDemoTimerBuffer(int type, const unsigned char *buffer);
+	void CustomTimerCommand(void);
+
+	enum {
+		SV_AG_NONE = -1,
+		SV_AG_UNKNOWN = 0,
+		SV_AG_MINI = 1,
+		SV_AG_FULL = 2,
+	};
+
+	int GetAgVersion();
+	float GetHudNextmap();
+	const char *GetNextmap();
+	void SetNextmap(const char *nextmap);
+
+private:
+
+	enum {
+		MAX_CUSTOM_TIMERS = 2,
+	};
+
+	void SyncTimer(float fTime);
+	void SyncTimerLocal(float fTime);
+	void SyncTimerRemote(unsigned int ip, unsigned short port, float fTime, double latency);
+	void DrawTimerInternal(int time, float ypos, int r, int g, int b, bool redOnLow);
+
+	float	m_flDemoSyncTime;
+	bool	m_bDemoSyncTimeValid;
+	float	m_flNextSyncTime;
+	bool	m_flSynced;
+	float	m_flEndTime;
+	float	m_flEffectiveTime;
+	bool	m_bDelayTimeleftReading;
+	float	m_flCustomTimerStart[MAX_CUSTOM_TIMERS];
+	float	m_flCustomTimerEnd[MAX_CUSTOM_TIMERS];
+	bool	m_bCustomTimerNeedSound[MAX_CUSTOM_TIMERS];
+	int		m_eAgVersion;
+	char	m_szNextmap[MAX_MAP_NAME];
+	bool	m_bNeedWriteTimer;
+	bool	m_bNeedWriteCustomTimer;
+	bool	m_bNeedWriteNextmap;
+
+	cvar_t *m_pCvarHudTimer;
+	cvar_t *m_pCvarHudTimerSync;
+	cvar_t *m_pCvarHudNextmap;
+	cvar_t *m_pCvarMpTimelimit;
+	cvar_t *m_pCvarMpTimeleft;
+	cvar_t *m_pCvarSvAgVersion;
+	cvar_t *m_pCvarAmxNextmap;
+
+	char	m_szPacketBuffer[22400];	// 16x1400 split packets
+	int		m_iResponceID;
+	int		m_iReceivedSize;
+	int		m_iReceivedPackets;
+	int		m_iReceivedPacketsCount;
+};
+
+#endif

--- a/cl_dll/CHudTrain.cpp
+++ b/cl_dll/CHudTrain.cpp
@@ -15,16 +15,17 @@
 //
 // Train.cpp
 //
-// implementation of CHudAmmo class
+// implementation of CHudTrain class
 //
 
+#include <stdio.h>
+#include <string.h>
+#include "CHudTrain.h"
 #include "hud.h"
 #include "cl_util.h"
-#include <string.h>
-#include <stdio.h>
 #include "parsemsg.h"
 
-DECLARE_MESSAGE(m_Train, Train )
+DECLARE_MESSAGE_PTR(m_Train, Train )
 
 
 int CHudTrain::Init(void)

--- a/cl_dll/CHudTrain.h
+++ b/cl_dll/CHudTrain.h
@@ -1,0 +1,20 @@
+#ifndef CHUDTRAIN_H
+#define CHUDTRAIN_H
+
+#include "CHudBase.h"
+
+class CHudTrain : public CHudBase
+{
+public:
+	int Init(void);
+	int VidInit(void);
+	int Draw(float flTime);
+	int MsgFunc_Train(const char *pszName, int iSize, void *pbuf);
+
+private:
+	HLHSPRITE m_hSprite;
+	int m_iPos;
+
+};
+
+#endif

--- a/cl_dll/GameStudioModelRenderer.cpp
+++ b/cl_dll/GameStudioModelRenderer.cpp
@@ -26,6 +26,7 @@
 
 #include "StudioModelRenderer.h"
 #include "GameStudioModelRenderer.h"
+#include "CHudSpectator.h"
 
 //
 // Override the StudioModelRender virtual member functions here to implement custom bone
@@ -220,7 +221,7 @@ char *CGameStudioModelRenderer::GetNextEnemyModel(void)
 		int maxClients = gEngfuncs.GetMaxClients();
 		for (int i = 0; i < maxClients; i++)
 		{
-			if (!gHUD.m_Spectator.IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1)))
+			if (!gHUD.m_Spectator->IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1)))
 				continue;
 			if (!_stricmp(m_szEnemyModels[j], m_szPlayerRemapModel[i]))
 			{
@@ -314,7 +315,7 @@ model_t *CGameStudioModelRenderer::GetPlayerModel(int playerIndex)
 		for (int i = 0; i < maxClients; i++)
 		{
 			if (i == playerIndex ||
-				!gHUD.m_Spectator.IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1)) ||
+				!gHUD.m_Spectator->IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1)) ||
 				_stricmp(m_szPlayerActualModel[i], actualModelName))
 				continue;
 			strcpy(m_szPlayerRemapModel[playerIndex], m_szPlayerRemapModel[i]);
@@ -473,7 +474,7 @@ void CGameStudioModelRenderer::ForceModelCommand(void)
 		{
 			if (i == m_iLocalPlayerIndex - 1) continue;
 			GetPlayerInfo(i + 1, &g_PlayerInfoList[i + 1]);
-			if (!gHUD.m_Spectator.IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1))) continue;
+			if (!gHUD.m_Spectator->IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1))) continue;
 			strncpy(plrName, g_PlayerInfoList[i + 1].name, MAX_PLAYER_NAME - 1);
 			plrName[MAX_PLAYER_NAME - 1] = 0;
 			_strlwr(plrName);
@@ -542,7 +543,7 @@ void CGameStudioModelRenderer::ForceColorsCommand(void)
 		{
 			if (i == m_iLocalPlayerIndex - 1) continue;
 			GetPlayerInfo(i + 1, &g_PlayerInfoList[i + 1]);
-			if (!gHUD.m_Spectator.IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1))) continue;
+			if (!gHUD.m_Spectator->IsActivePlayer(gEngfuncs.GetEntityByIndex(i + 1))) continue;
 			strncpy(plrName, g_PlayerInfoList[i + 1].name, MAX_PLAYER_NAME - 1);
 			plrName[MAX_PLAYER_NAME - 1] = 0;
 			_strlwr(plrName);

--- a/cl_dll/aghudnextmap.cpp
+++ b/cl_dll/aghudnextmap.cpp
@@ -3,6 +3,7 @@
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
+#include "CHudTimer.h"
 
 DECLARE_MESSAGE(m_Nextmap, Nextmap)
 
@@ -55,9 +56,9 @@ int AgHudNextmap::MsgFunc_Nextmap(const char *pszName, int iSize, void *pbuf)
 	BEGIN_READ(pbuf, iSize);
 	strcpy(m_szNextmap, READ_STRING());
 
-	gHUD.m_Timer.SetNextmap(m_szNextmap);
+	gHUD.m_Timer->SetNextmap(m_szNextmap);
 
-	const int hud_nextmap = (int)gHUD.m_Timer.GetHudNextmap();
+	const int hud_nextmap = (int)gHUD.m_Timer->GetHudNextmap();
 	if (hud_nextmap != 2 && hud_nextmap != 1)
 	{
 		m_flTurnoff = gHUD.m_flTime + 10; // Display for 10 seconds.

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -28,6 +28,7 @@
 #include "netadr.h"
 #include "vgui_schememanager.h"
 #include "GameStudioModelRenderer.h"
+#include "CHudSpectator.h"
 
 extern "C"
 {
@@ -438,7 +439,7 @@ Called when a director event message was received
 
 void DLLEXPORT HUD_DirectorMessage( int iSize, void *pbuf )
 {
-	 gHUD.m_Spectator.DirectorMessage( iSize, pbuf );
+	 gHUD.m_Spectator->DirectorMessage( iSize, pbuf );
 }
 
 

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -31,11 +31,23 @@
 							return gHUD.##y.MsgFunc_##x(pszName, iSize, pbuf ); \
 							}
 
+// If gHUD.y is a pointer
+#define DECLARE_MESSAGE_PTR(y, x) int __MsgFunc_##x(const char *pszName, int iSize, void *pbuf) \
+							{ \
+							return gHUD.##y->MsgFunc_##x(pszName, iSize, pbuf ); \
+							}
+
 
 #define HOOK_COMMAND(x, y) gEngfuncs.pfnAddCommand( x, __CmdFunc_##y );
 #define DECLARE_COMMAND(y, x) void __CmdFunc_##x( void ) \
 							{ \
 								gHUD.##y.UserCmd_##x( ); \
+							}
+
+// If gHUD.y is a pointer
+#define DECLARE_COMMAND_PTR(y, x) void __CmdFunc_##x( void ) \
+							{ \
+								gHUD.##y->UserCmd_##x( ); \
 							}
 
 inline float CVAR_GET_FLOAT( const char *x ) {	return gEngfuncs.pfnGetCvarFloat( (char*)x ); }

--- a/cl_dll/demo.cpp
+++ b/cl_dll/demo.cpp
@@ -17,6 +17,7 @@
 #include "demo.h"
 #include "demo_api.h"
 #include <memory.h>
+#include "CHudTimer.h"
 
 #define DLLEXPORT __declspec( dllexport )
 
@@ -100,7 +101,7 @@ void DLLEXPORT Demo_ReadBuffer( int size, unsigned char *buffer )
 	case TYPE_TIMER:
 	case TYPE_CUSTOM_TIMER:
 	case TYPE_NEXTMAP:
-		gHUD.m_Timer.ReadDemoTimerBuffer(type, buffer + i);
+		gHUD.m_Timer->ReadDemoTimerBuffer(type, buffer + i);
 		break;
 	default:
 		gEngfuncs.Con_DPrintf( "Unknown demo buffer type, skipping.\n" );

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -19,6 +19,7 @@
 #include "pm_defs.h"
 #include "pmtrace.h"	
 #include "pm_shared.h"
+#include "CHudSpectator.h"
 
 #define DLLEXPORT __declspec( dllexport )
 
@@ -71,9 +72,9 @@ int DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *mode
 
 	if ( g_iUser1 )
 	{
-		gHUD.m_Spectator.AddOverviewEntity( type, ent, modelname );
+		gHUD.m_Spectator->AddOverviewEntity( type, ent, modelname );
 
-		if ( ( g_iUser1 == OBS_IN_EYE || gHUD.m_Spectator.m_pip->value == INSET_IN_EYE ) &&
+		if ( ( g_iUser1 == OBS_IN_EYE || gHUD.m_Spectator->m_pip->value == INSET_IN_EYE ) &&
 				ent->index == g_iUser2 )
 			return 0;	// don't draw the player we are following in eye
 

--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -24,8 +24,9 @@
 #include "eventscripts.h"
 #include "event_api.h"
 #include "pm_shared.h"
+#include "CHudSpectator.h"
 
-#define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator.m_pip->value == INSET_IN_EYE)) )
+#define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator->m_pip->value == INSET_IN_EYE)) )
 /*
 =================
 GetEntity

--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -35,13 +35,14 @@
 #include "r_studioint.h"
 #include "com_model.h"
 #include "eiface.h"
+#include "CHudSpectator.h"
 
 extern "C"
 {
 #include "pm_shared.h"
 }
 
-#define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator.m_pip->value == INSET_IN_EYE)) )
+#define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator->m_pip->value == INSET_IN_EYE)) )
 
 extern engine_studio_api_t IEngineStudio;
 
@@ -1355,7 +1356,7 @@ void EV_FireRpg( event_args_t *args )
 //======================
 
 //======================
-//	    EGON END 
+//	    EGON START 
 //======================
 enum egon_e {
 	EGON_IDLE1 = 0,

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -32,22 +32,12 @@
 
 bool ParseColor( char *string, RGBA &rgba );
 
-//
-//-----------------------------------------------------
-// TODO: replace with an STL container
-struct HUDLIST {
-	CHudBase	*p;
-	HUDLIST		*pNext;
-};
-
-//
-//-----------------------------------------------------
-//
 #include "..\game_shared\voice_status.h"
 
 //-----------------------------------------------------
 // Forward declarations
 //-----------------------------------------------------
+class TeamFortressViewport;
 class CHudSpectator;
 class CHudAmmo;
 class CHudAmmoSecondary;
@@ -139,6 +129,7 @@ struct CharWidths
 
 #define HUD_ELEM_INIT_FULL(type, var) var = new type(); var->m_isDeletable = true; var->Init();
 #define HUD_ELEM_INIT(x) m_##x = new CHud##x(); m_##x->m_isDeletable = true; m_##x->Init();
+
 class CHud
 {
 public:
@@ -288,8 +279,6 @@ private:
 
 	struct cvar_s *default_fov;
 };
-
-class TeamFortressViewport;
 
 extern CHud gHUD;
 extern TeamFortressViewport *gViewPort;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -24,6 +24,7 @@
 #define CHUD_H
 
 #include <list>
+#include <memory>
 #include "wrect.h"
 #include "cl_dll.h"
 #include "ammo.h"
@@ -127,8 +128,8 @@ struct CharWidths
 #include "aghudtimeout.h"
 #include "aghudvote.h"
 
-#define HUD_ELEM_INIT_FULL(type, var) var = new type(); var->m_isDeletable = true; var->Init();
-#define HUD_ELEM_INIT(x) m_##x = new CHud##x(); m_##x->m_isDeletable = true; m_##x->Init();
+#define HUD_ELEM_INIT_FULL(type, var) var = std::unique_ptr<type>(new type()); var->m_isDeletable = true; var->Init();
+#define HUD_ELEM_INIT(x) HUD_ELEM_INIT_FULL(CHud##x, m_##x)
 
 class CHud
 {
@@ -147,23 +148,23 @@ public:
 	//-----------------------------------------------------
 	// HUD elements
 	//-----------------------------------------------------
-	CHudAmmo			*m_Ammo	= nullptr;
-	CHudHealth			*m_Health = nullptr;
-	CHudSpectator		*m_Spectator = nullptr;
-	CHudGeiger			*m_Geiger = nullptr;
-	CHudBattery			*m_Battery = nullptr;
-	CHudTrain			*m_Train = nullptr;
-	CHudFlashlight		*m_Flash = nullptr;
-	CHudMessage			*m_Message = nullptr;
-	CHudStatusBar		*m_StatusBar = nullptr;
-	CHudDeathNotice		*m_DeathNotice = nullptr;
-	CHudSayText			*m_SayText = nullptr;
-	CHudMenu			*m_Menu = nullptr;
-	CHudAmmoSecondary	*m_AmmoSecondary = nullptr;
-	CHudTextMessage		*m_TextMessage = nullptr;
-	CHudStatusIcons		*m_StatusIcons = nullptr;
-	CHudTimer			*m_Timer = nullptr;
-	CHudScores			*m_Scores = nullptr;
+	std::unique_ptr<CHudAmmo>			m_Ammo	= nullptr;
+	std::unique_ptr<CHudHealth>			m_Health = nullptr;
+	std::unique_ptr<CHudSpectator>		m_Spectator = nullptr;
+	std::unique_ptr<CHudGeiger>			m_Geiger = nullptr;
+	std::unique_ptr<CHudBattery>		m_Battery = nullptr;
+	std::unique_ptr<CHudTrain>			m_Train = nullptr;
+	std::unique_ptr<CHudFlashlight>		m_Flash = nullptr;
+	std::unique_ptr<CHudMessage>		m_Message = nullptr;
+	std::unique_ptr<CHudStatusBar>		m_StatusBar = nullptr;
+	std::unique_ptr<CHudDeathNotice>	m_DeathNotice = nullptr;
+	std::unique_ptr<CHudSayText>		m_SayText = nullptr;
+	std::unique_ptr<CHudMenu>			m_Menu = nullptr;
+	std::unique_ptr<CHudAmmoSecondary>	m_AmmoSecondary = nullptr;
+	std::unique_ptr<CHudTextMessage>	m_TextMessage = nullptr;
+	std::unique_ptr<CHudStatusIcons>	m_StatusIcons = nullptr;
+	std::unique_ptr<CHudTimer>			m_Timer = nullptr;
+	std::unique_ptr<CHudScores>			m_Scores = nullptr;
 
 	//-----------------------------------------------------
 	// AG HUD elements

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -249,7 +249,6 @@ public:
 	float GetHudTransparency();
 
 private:
-	//HUDLIST					*m_pHudList;
 	std::list<CHudBase *>	m_HudList;
 	HLHSPRITE				m_hsprLogo;
 	int						m_iLogo;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -23,6 +23,7 @@
 #ifndef CHUD_H
 #define CHUD_H
 
+#include <list>
 #include "wrect.h"
 #include "cl_dll.h"
 #include "ammo.h"
@@ -136,8 +137,8 @@ struct CharWidths
 #include "aghudtimeout.h"
 #include "aghudvote.h"
 
-#define HUD_ELEM_INIT_FULL(type, var) var = new type(); var->Init();
-#define HUD_ELEM_INIT(x) m_##x = new CHud##x(); m_##x->Init();
+#define HUD_ELEM_INIT_FULL(type, var) var = new type(); var->m_isDeletable = true; var->Init();
+#define HUD_ELEM_INIT(x) m_##x = new CHud##x(); m_##x->m_isDeletable = true; m_##x->Init();
 class CHud
 {
 public:
@@ -194,10 +195,12 @@ public:
 	int Redraw(float flTime, int intermission);
 	int UpdateClientData(client_data_t *cdata, float time);
 
-	CHud() : m_iSpriteCount(0), m_pHudList(NULL) {}
+	CHud();
 	~CHud();			// destructor, frees allocated memory
 
-						// user messages
+	//-----------------------------------------------------
+	// User messages
+	//-----------------------------------------------------
 	int _cdecl MsgFunc_Damage(const char *pszName, int iSize, void *pbuf);
 	int _cdecl MsgFunc_GameMode(const char *pszName, int iSize, void *pbuf);
 	int _cdecl MsgFunc_Logo(const char *pszName, int iSize, void *pbuf);
@@ -217,8 +220,7 @@ public:
 	// sprite indexes
 	int m_HUD_number_0;
 
-
-	void AddHudElem(CHudBase *p);
+	void AddHudElem(CHudBase *elem);
 
 	float GetSensitivity();
 
@@ -256,7 +258,8 @@ public:
 	float GetHudTransparency();
 
 private:
-	HUDLIST					*m_pHudList;
+	//HUDLIST					*m_pHudList;
+	std::list<CHudBase *>	m_HudList;
 	HLHSPRITE				m_hsprLogo;
 	int						m_iLogo;
 	client_sprite_t			*m_pSpriteList;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -20,293 +20,54 @@
 // CHud handles the message, calculation, and drawing the HUD
 //
 
-
-#define RGB_YELLOWISH	0x00FFA000 //255,160,0
-#define RGB_REDISH		0x00FF1010 //255,160,0
-#define RGB_GREENISH	0x0000A000 //0,160,0
+#ifndef CHUD_H
+#define CHUD_H
 
 #include "wrect.h"
 #include "cl_dll.h"
 #include "ammo.h"
 #include <eiface.h>
-
-#define DHN_DRAWZERO	1
-#define DHN_2DIGITS		2
-#define DHN_3DIGITS		4
-#define MIN_ALPHA		100
-#define ALPHA_AMMO_FLASH	100
-#define ALPHA_AMMO_MAX		128
-#define ALPHA_POINTS_FLASH	128
-#define ALPHA_POINTS_MAX	155
-
-#define HUDELEM_ACTIVE	1
-
-typedef struct {
-	int x, y;
-} POSITION;
-
-union RGBA {
-	struct { unsigned char r, g, b, a; };
-	unsigned int c;
-
-	RGBA() { c = 0; }
-	RGBA(unsigned int value) { c = value; }
-	void Set(unsigned char r1, unsigned char g1, unsigned char b1) { r = r1; g = g1; b = b1; a = 255; }
-};
+#include "CHudBase.h"
 
 bool ParseColor( char *string, RGBA &rgba );
 
-typedef struct cvar_s cvar_t;
-
-
-#define HUD_ACTIVE			1
-#define HUD_INTERMISSION	2
-
-#define MAX_HUD_STRING			80
-#define MAX_MOTD_LENGTH			1536
-#define MAX_STEAMID				32	// 0:0:4294967295, STEAM_ID_PENDING
-#define MAX_MAP_NAME			64
-
-#define ADJUST_MENU		-5	// space correction between text lines in hud menu in pixels
-#define ADJUST_MESSAGE	0	// space correction between text lines in hud messages in pixels
-
 //
 //-----------------------------------------------------
-//
-class CHudBase
-{
-public:
-	POSITION  m_pos;
-	int   m_type;
-	int	  m_iFlags; // active, moving, 
-	virtual		~CHudBase() {}
-	virtual int Init( void ) {return 0;}
-	virtual int VidInit( void ) {return 0;}
-	virtual int Draw(float flTime) {return 0;}
-	virtual void Think(void) {return;}
-	virtual void Reset(void) {return;}
-	virtual void InitHUDData( void ) {}		// called every time a server is connected to
-
-};
-
+// TODO: replace with an STL container
 struct HUDLIST {
 	CHudBase	*p;
 	HUDLIST		*pNext;
 };
 
-
-
 //
 //-----------------------------------------------------
 //
 #include "..\game_shared\voice_status.h"
-#include "hud_spectator.h"
 
-
-//
 //-----------------------------------------------------
-//
-class CHudAmmo: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	void Think(void);
-	void Reset(void);
-	int DrawWList(float flTime);
-	void UpdateCrosshair();
-	int MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf);
-	int MsgFunc_WeaponList(const char *pszName, int iSize, void *pbuf);
-	int MsgFunc_AmmoX(const char *pszName, int iSize, void *pbuf);
-	int MsgFunc_AmmoPickup( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_WeapPickup( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_ItemPickup( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_HideWeapon( const char *pszName, int iSize, void *pbuf );
-
-	int GetMaxSlot(void) { return m_iMaxSlot; }
-	void SlotInput( int iSlot );
-	void _cdecl UserCmd_Slot1( void );
-	void _cdecl UserCmd_Slot2( void );
-	void _cdecl UserCmd_Slot3( void );
-	void _cdecl UserCmd_Slot4( void );
-	void _cdecl UserCmd_Slot5( void );
-	void _cdecl UserCmd_Slot6( void );
-	void _cdecl UserCmd_Slot7( void );
-	void _cdecl UserCmd_Slot8( void );
-	void _cdecl UserCmd_Slot9( void );
-	void _cdecl UserCmd_Slot10( void );
-	void _cdecl UserCmd_Close( void );
-	void _cdecl UserCmd_NextWeapon( void );
-	void _cdecl UserCmd_PrevWeapon( void );
-
-private:
-	float	m_fFade;
-	WEAPON	*m_pWeapon;
-	int		m_fOnTarget;
-	int		m_HUD_bucket0;
-	int		m_HUD_selection;
-	int		m_iMaxSlot;	// There are 5 (0-4) slots by default and they can extend to 6. This will be used to draw additional weapon bucket(s) on a hud.
-
-	cvar_t	*m_pCvarHudWeapon;
-};
-
-//
+// Forward declarations
 //-----------------------------------------------------
-//
+class CHudSpectator;
+class CHudAmmo;
+class CHudAmmoSecondary;
+class CHudHealth;
+class CHudGeiger;
+class CHudTrain;
+class CHudStatusBar;
+class CHudDeathNotice;
+class CHudMenu;
+class CHudSayText;
+class CHudBattery;
+class CHudFlashlight;
+class CHudTextMessage;
+class CHudMessage;
+class CHudTimer;
+class CHudScores;
+class CHudStatusIcons;
 
-class CHudAmmoSecondary: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	void Reset( void );
-	int Draw(float flTime);
-
-	int MsgFunc_SecAmmoVal( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_SecAmmoIcon( const char *pszName, int iSize, void *pbuf );
-
-private:
-	enum {
-		MAX_SEC_AMMO_VALUES = 4
-	};
-
-	int m_HUD_ammoicon; // sprite indices
-	int m_iAmmoAmounts[MAX_SEC_AMMO_VALUES];
-	float m_fFade;
-};
-
-
-#include "health.h"
-
-
-#define FADE_TIME 100
-
-
-//
 //-----------------------------------------------------
-//
-class CHudGeiger: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	int MsgFunc_Geiger(const char *pszName, int iSize, void *pbuf);
-	
-private:
-	int m_iGeigerRange;
-
-};
-
-//
+// Game info structures declaration
 //-----------------------------------------------------
-//
-class CHudTrain: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	int MsgFunc_Train(const char *pszName, int iSize, void *pbuf);
-
-private:
-	HLHSPRITE m_hSprite;
-	int m_iPos;
-
-};
-
-//
-//-----------------------------------------------------
-//
-// REMOVED: Vgui has replaced this.
-//
-/*
-class CHudMOTD : public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw( float flTime );
-	void Reset( void );
-
-	int MsgFunc_MOTD( const char *pszName, int iSize, void *pbuf );
-
-protected:
-	static int MOTD_DISPLAY_TIME;
-	char m_szMOTD[ MAX_MOTD_LENGTH ];
-	float m_flActiveRemaining;
-	int m_iLines;
-};
-*/
-
-//
-//-----------------------------------------------------
-//
-class CHudStatusBar : public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw( float flTime );
-	void Reset( void );
-	void ParseStatusString( int line_num );
-
-	int MsgFunc_StatusText( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_StatusValue( const char *pszName, int iSize, void *pbuf );
-
-protected:
-	enum { 
-		MAX_STATUSTEXT_LENGTH = 128,
-		MAX_STATUSBAR_VALUES = 8,
-		MAX_STATUSBAR_LINES = 2,
-	};
-
-	char m_szStatusText[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];  // a text string describing how the status bar is to be drawn
-	char m_szStatusBar[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];	// the constructed bar that is drawn
-	int m_iStatusValues[MAX_STATUSBAR_VALUES];  // an array of values for use in the status bar
-
-	int m_bReparseString; // set to TRUE whenever the m_szStatusBar needs to be recalculated
-
-	// an array of colors...one color for each line
-	float *m_pflNameColors[MAX_STATUSBAR_LINES];
-};
-
-//
-//-----------------------------------------------------
-//
-// REMOVED: Vgui has replaced this.
-//
-/*
-class CHudScoreboard: public CHudBase
-{
-public:
-	int Init( void );
-	void InitHUDData( void );
-	int VidInit( void );
-	int Draw( float flTime );
-	int DrawPlayers( int xoffset, float listslot, int nameoffset = 0, char *team = NULL ); // returns the ypos where it finishes drawing
-	void UserCmd_ShowScores( void );
-	void UserCmd_HideScores( void );
-	int MsgFunc_ScoreInfo( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_TeamInfo( const char *pszName, int iSize, void *pbuf );
-	int MsgFunc_TeamScore( const char *pszName, int iSize, void *pbuf );
-	void DeathMsg( int killer, int victim );
-
-	int m_iNumTeams;
-
-	int m_iLastKilledBy;
-	int m_fLastKillTime;
-	int m_iPlayerNum;
-	int m_iShowscoresHeld;
-
-	void GetAllPlayersInfo( void );
-private:
-	struct cvar_s *cl_showpacketloss;
-
-};
-*/
-
 struct extra_player_info_t 
 {
 	short frags;
@@ -330,335 +91,18 @@ struct team_info_t
 	int teamnumber;
 };
 
+//-----------------------------------------------------
+// Game info global variables
+//-----------------------------------------------------
 extern hud_player_info_t	g_PlayerInfoList[MAX_PLAYERS + 1];		// player info from the engine
 extern extra_player_info_t	g_PlayerExtraInfo[MAX_PLAYERS + 1];		// additional player info sent directly to the client dll
 extern team_info_t			g_TeamInfo[MAX_TEAMS + 1];
 extern int					g_IsSpectator[MAX_PLAYERS + 1];
 extern char					g_PlayerSteamId[MAX_PLAYERS + 1][MAX_STEAMID + 1];
 
-
-//
 //-----------------------------------------------------
-//
-class CHudDeathNotice : public CHudBase
-{
-public:
-	int Init( void );
-	void InitHUDData( void );
-	int VidInit( void );
-	int Draw( float flTime );
-	int MsgFunc_DeathMsg( const char *pszName, int iSize, void *pbuf );
-
-private:
-	int m_HUD_d_skull;  // sprite index of skull icon
-};
-
-//
+// CharWidths
 //-----------------------------------------------------
-//
-class CHudMenu : public CHudBase
-{
-public:
-	int Init( void );
-	void InitHUDData( void );
-	int VidInit( void );
-	void Reset( void );
-	int Draw( float flTime );
-	int MsgFunc_ShowMenu( const char *pszName, int iSize, void *pbuf );
-
-	void SelectMenuItem( int menu_item );
-
-	int m_fMenuDisplayed;
-	int m_bitsValidSlots;
-	float m_flShutoffTime;
-	int m_fWaitingForMore;
-};
-
-//
-//-----------------------------------------------------
-//
-class CHudSayText : public CHudBase
-{
-public:
-	int Init( void );
-	void InitHUDData( void );
-	int VidInit( void );
-	int Draw( float flTime );
-	int MsgFunc_SayText( const char *pszName, int iSize, void *pbuf );
-	void SayTextPrint( const char *pszBuf, int iBufSize, int clientIndex = -1 );
-	void EnsureTextFitsInOneLineAndWrapIfHaveTo( int line );
-friend class CHudSpectator;
-
-private:
-	struct cvar_s *	m_HUD_saytext;
-	struct cvar_s *	m_HUD_saytext_time;
-	cvar_t	*m_pCvarConSayColor;
-};
-
-//
-//-----------------------------------------------------
-//
-class CHudBattery: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	int MsgFunc_Battery(const char *pszName,  int iSize, void *pbuf );
-	
-private:
-	HLHSPRITE m_hSprite1;
-	HLHSPRITE m_hSprite2;
-	wrect_t *m_prc1;
-	wrect_t *m_prc2;
-	int	  m_iBat;	
-	float m_fFade;
-	int	  m_iHeight;		// width of the battery innards
-};
-
-
-//
-//-----------------------------------------------------
-//
-class CHudFlashlight: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	void Reset( void );
-	int MsgFunc_Flashlight(const char *pszName,  int iSize, void *pbuf );
-	int MsgFunc_FlashBat(const char *pszName,  int iSize, void *pbuf );
-	
-private:
-	HLHSPRITE m_hSprite1;
-	HLHSPRITE m_hSprite2;
-	HLHSPRITE m_hBeam;
-	wrect_t *m_prc1;
-	wrect_t *m_prc2;
-	wrect_t *m_prcBeam;
-	float m_flBat;
-	int	  m_iBat;
-	int	  m_fOn;
-	float m_fFade;
-	int	  m_iWidth;		// width of the battery innards
-};
-
-//
-//-----------------------------------------------------
-//
-const int maxHUDMessages = 16;
-struct message_parms_t
-{
-	client_textmessage_t	*pMessage;
-	float	time;
-	int x, y;
-	int	totalWidth, totalHeight;
-	int width;
-	int lines;
-	int lineLength;
-	int length;
-	int r, g, b;
-	int currentChar;
-	int fadeBlend;
-	float charTime;
-	float fadeTime;
-};
-
-//
-//-----------------------------------------------------
-//
-
-class CHudTextMessage: public CHudBase
-{
-public:
-	int Init( void );
-	static char *LocaliseTextString( const char *msg, char *dst_buffer, int buffer_size );
-	static char *BufferedLocaliseTextString( const char *msg );
-	char *LookupString( const char *msg_name, int *msg_dest = NULL );
-	int MsgFunc_TextMsg(const char *pszName, int iSize, void *pbuf);
-};
-
-//
-//-----------------------------------------------------
-//
-
-class CHudMessage: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	int Draw(float flTime);
-	int MsgFunc_HudText(const char *pszName, int iSize, void *pbuf);
-	int MsgFunc_GameTitle(const char *pszName, int iSize, void *pbuf);
-
-	float FadeBlend( float fadein, float fadeout, float hold, float localTime );
-	int	XPosition( float x, int width, int lineWidth );
-	int YPosition( float y, int height );
-
-	void MessageAdd( const char *pName, float time );
-	void MessageAdd(client_textmessage_t * newMessage );
-	void MessageDrawScan( client_textmessage_t *pMessage, float time );
-	void MessageScanStart( void );
-	void MessageScanNextChar( void );
-	void Reset( void );
-
-private:
-	client_textmessage_t		*m_pMessages[maxHUDMessages];
-	float						m_startTime[maxHUDMessages];
-	message_parms_t				m_parms;
-	float						m_gameTitleTime;
-	client_textmessage_t		*m_pGameTitle;
-
-	int m_HUD_title_life;
-	int m_HUD_title_half;
-};
-
-//
-//-----------------------------------------------------
-//
-
-class CHudTimer: public CHudBase
-{
-public:
-	int Init(void);
-	int VidInit(void);
-	void Think(void);
-	int Draw(float flTime);
-
-	int MsgFunc_Timer(const char *pszName, int iSize, void *pbuf);
-
-	void DoResync(void);
-	void ReadDemoTimerBuffer(int type, const unsigned char *buffer);
-	void CustomTimerCommand(void);
-
-	enum {
-		SV_AG_NONE = -1,
-		SV_AG_UNKNOWN = 0,
-		SV_AG_MINI = 1,
-		SV_AG_FULL = 2,
-	};
-
-	int GetAgVersion(void) { return m_eAgVersion; }
-	float GetHudNextmap(void) { return m_pCvarHudNextmap->value; }
-	const char* GetNextmap(void) { return m_szNextmap; }
-	void SetNextmap(const char *nextmap)
-	{
-		strncpy(m_szNextmap, nextmap, HLARRAYSIZE(m_szNextmap) - 1);
-		m_szNextmap[HLARRAYSIZE(m_szNextmap) - 1] = 0;
-	}
-
-private:
-
-	enum {
-		MAX_CUSTOM_TIMERS = 2,
-	};
-
-	void SyncTimer(float fTime);
-	void SyncTimerLocal(float fTime);
-	void SyncTimerRemote(unsigned int ip, unsigned short port, float fTime, double latency);
-	void DrawTimerInternal(int time, float ypos, int r, int g, int b, bool redOnLow);
-
-	float	m_flDemoSyncTime;
-	bool	m_bDemoSyncTimeValid;
-	float	m_flNextSyncTime;
-	bool	m_flSynced;
-	float	m_flEndTime;
-	float	m_flEffectiveTime;
-	bool	m_bDelayTimeleftReading;
-	float	m_flCustomTimerStart[MAX_CUSTOM_TIMERS];
-	float	m_flCustomTimerEnd[MAX_CUSTOM_TIMERS];
-	bool	m_bCustomTimerNeedSound[MAX_CUSTOM_TIMERS];
-	int		m_eAgVersion;
-	char	m_szNextmap[MAX_MAP_NAME];
-	bool	m_bNeedWriteTimer;
-	bool	m_bNeedWriteCustomTimer;
-	bool	m_bNeedWriteNextmap;
-
-	cvar_t *m_pCvarHudTimer;
-	cvar_t *m_pCvarHudTimerSync;
-	cvar_t *m_pCvarHudNextmap;
-	cvar_t *m_pCvarMpTimelimit;
-	cvar_t *m_pCvarMpTimeleft;
-	cvar_t *m_pCvarSvAgVersion;
-	cvar_t *m_pCvarAmxNextmap;
-
-	char	m_szPacketBuffer[22400];	// 16x1400 split packets
-	int		m_iResponceID;
-	int		m_iReceivedSize;
-	int		m_iReceivedPackets;
-	int		m_iReceivedPacketsCount;
-};
-
-//
-//-----------------------------------------------------
-//
-
-struct HudScoresData
-{
-	char szScore[64];
-	int r, g, b;
-};
-
-class CHudScores : public CHudBase
-{
-public:
-	int Init(void);
-	int VidInit(void);
-	int Draw(float flTime);
-
-private:
-	HudScoresData m_ScoresData[MAX_PLAYERS] = {};
-	int m_iLines = 0;
-	int m_iOverLay = 0;
-	float m_flScoreBoardLastUpdated = 0;
-	cvar_t* m_pCvarHudScores = NULL;
-	cvar_t* m_pCvarHudScoresPos = NULL;
-};
-
-//
-//-----------------------------------------------------
-//
-#define MAX_SPRITE_NAME_LENGTH		24
-#define RESERVE_SPRITES_FOR_WEAPONS	32
-
-class CHudStatusIcons: public CHudBase
-{
-public:
-	int Init( void );
-	int VidInit( void );
-	void Reset( void );
-	int Draw(float flTime);
-	int MsgFunc_StatusIcon(const char *pszName, int iSize, void *pbuf);
-
-	enum { 
-		MAX_ICONSPRITENAME_LENGTH = MAX_SPRITE_NAME_LENGTH,
-		MAX_ICONSPRITES = 4,
-	};
-
-	
-	//had to make these public so CHud could access them (to enable concussion icon)
-	//could use a friend declaration instead...
-	void EnableIcon( char *pszIconName, unsigned char red, unsigned char green, unsigned char blue );
-	void DisableIcon( char *pszIconName );
-
-private:
-
-	typedef struct
-	{
-		char szSpriteName[MAX_ICONSPRITENAME_LENGTH];
-		HLHSPRITE spr;
-		wrect_t rc;
-		unsigned char r, g, b;
-	} icon_sprite_t;
-
-	icon_sprite_t m_IconList[MAX_ICONSPRITES];
-
-};
-
-//
-//-----------------------------------------------------
-//
 #define MAX_BASE_CHARS 255
 struct CharWidths
 {
@@ -677,6 +121,9 @@ struct CharWidths
 	}
 };
 
+//-----------------------------------------------------
+// AG hud elements
+//-----------------------------------------------------
 #include "aghudglobal.h"
 #include "aghudcountdown.h"
 #include "aghudctf.h"
@@ -689,8 +136,125 @@ struct CharWidths
 #include "aghudtimeout.h"
 #include "aghudvote.h"
 
+#define HUD_ELEM_INIT_FULL(type, var) var = new type(); var->Init();
+#define HUD_ELEM_INIT(x) m_##x = new CHud##x(); m_##x->Init();
 class CHud
 {
+public:
+	inline HLHSPRITE GetSprite(int index)
+	{
+		return (index < 0) ? 0 : m_rghSprites[index];
+	}
+	inline wrect_t& GetSpriteRect(int index)
+	{
+		return m_rgrcRects[index];
+	}
+	int GetSpriteIndex(const char *SpriteName);	// gets a sprite index, for use in the m_rghSprites[] array
+	void AddSprite(client_sprite_t *p);
+
+	//-----------------------------------------------------
+	// HUD elements
+	//-----------------------------------------------------
+	CHudAmmo			*m_Ammo	= nullptr;
+	CHudHealth			*m_Health = nullptr;
+	CHudSpectator		*m_Spectator = nullptr;
+	CHudGeiger			*m_Geiger = nullptr;
+	CHudBattery			*m_Battery = nullptr;
+	CHudTrain			*m_Train = nullptr;
+	CHudFlashlight		*m_Flash = nullptr;
+	CHudMessage			*m_Message = nullptr;
+	CHudStatusBar		*m_StatusBar = nullptr;
+	CHudDeathNotice		*m_DeathNotice = nullptr;
+	CHudSayText			*m_SayText = nullptr;
+	CHudMenu			*m_Menu = nullptr;
+	CHudAmmoSecondary	*m_AmmoSecondary = nullptr;
+	CHudTextMessage		*m_TextMessage = nullptr;
+	CHudStatusIcons		*m_StatusIcons = nullptr;
+	CHudTimer			*m_Timer = nullptr;
+	CHudScores			*m_Scores = nullptr;
+
+	//-----------------------------------------------------
+	// AG HUD elements
+	//-----------------------------------------------------
+	AgHudGlobal			m_Global;
+	AgHudCountdown		m_Countdown;
+	AgHudCTF			m_CTF;
+	AgHudLocation		m_Location;
+	AgHudLongjump		m_Longjump;
+	AgHudNextmap		m_Nextmap;
+	AgHudPlayerId		m_PlayerId;
+	AgHudSettings		m_Settings;
+	AgHudSuddenDeath	m_SuddenDeath;
+	AgHudTimeout		m_Timeout;
+	AgHudVote			m_Vote;
+
+	void Init(void);
+	void VidInit(void);
+	void Think(void);
+	int Redraw(float flTime, int intermission);
+	int UpdateClientData(client_data_t *cdata, float time);
+
+	CHud() : m_iSpriteCount(0), m_pHudList(NULL) {}
+	~CHud();			// destructor, frees allocated memory
+
+						// user messages
+	int _cdecl MsgFunc_Damage(const char *pszName, int iSize, void *pbuf);
+	int _cdecl MsgFunc_GameMode(const char *pszName, int iSize, void *pbuf);
+	int _cdecl MsgFunc_Logo(const char *pszName, int iSize, void *pbuf);
+	int _cdecl MsgFunc_ResetHUD(const char *pszName, int iSize, void *pbuf);
+	void _cdecl MsgFunc_InitHUD(const char *pszName, int iSize, void *pbuf);
+	void _cdecl MsgFunc_ViewMode(const char *pszName, int iSize, void *pbuf);
+	int _cdecl MsgFunc_SetFOV(const char *pszName, int iSize, void *pbuf);
+	int  _cdecl MsgFunc_Concuss(const char *pszName, int iSize, void *pbuf);
+
+	// Screen information
+	SCREENINFO	m_scrinfo;
+
+	int	m_iWeaponBits;
+	int	m_fPlayerDead;
+	int m_iIntermission;
+
+	// sprite indexes
+	int m_HUD_number_0;
+
+
+	void AddHudElem(CHudBase *p);
+
+	float GetSensitivity();
+
+	HLHSPRITE	m_hsprCursor;
+	float	m_flTime;	   // the current client time
+	float	m_fOldTime;  // the time at which the HUD was last redrawn
+	double	m_flTimeDelta; // the difference between flTime and fOldTime
+	Vector	m_vecOrigin;
+	Vector	m_vecAngles;
+	int		m_iKeyBits;
+	int		m_iHideHUDDisplay;
+	int		m_iFOV;
+	int		m_Teamplay;
+	int		m_iRes;
+	cvar_t	*m_pCvarBunnyHop;
+	cvar_t	*m_pCvarStealMouse;
+	cvar_t	*m_pCvarDraw;
+	cvar_t	*m_pCvarDim;
+	cvar_t	*m_pCvarShowNextmap;
+	cvar_t	*m_pCvarShowLoss;
+	cvar_t	*m_pCvarShowSteamId;
+	cvar_t	*m_pCvarShowKd;
+	cvar_t	*m_pCvarColorText;
+	cvar_t	*m_pCvarRDynamicEntLight;
+
+	int m_iFontHeight;
+	int DrawHudNumber(int x, int y, int iFlags, int iNumber, int r, int g, int b);
+	int DrawHudString(int x, int y, const char *szString, int r, int g, int b);
+	int DrawHudStringReverse(int xpos, int ypos, const char *szString, int r, int g, int b);
+	int DrawHudNumberString(int xpos, int ypos, int iNumber, int r, int g, int b);
+	int GetNumWidth(int iNumber, int iFlags);
+	int GetHudCharWidth(int c);
+	int CalculateCharWidth(int c);
+	void GetHudColor(int hudPart, int value, int &r, int &g, int &b);
+	float GetHudTransparency();
+
 private:
 	HUDLIST					*m_pHudList;
 	HLHSPRITE				m_hsprLogo;
@@ -713,41 +277,6 @@ private:
 	RGBA	m_hudColor2;
 	RGBA	m_hudColor3;
 
-public:
-
-	HLHSPRITE						m_hsprCursor;
-	float m_flTime;	   // the current client time
-	float m_fOldTime;  // the time at which the HUD was last redrawn
-	double m_flTimeDelta; // the difference between flTime and fOldTime
-	Vector	m_vecOrigin;
-	Vector	m_vecAngles;
-	int		m_iKeyBits;
-	int		m_iHideHUDDisplay;
-	int		m_iFOV;
-	int		m_Teamplay;
-	int		m_iRes;
-	cvar_t	*m_pCvarBunnyHop;
-	cvar_t	*m_pCvarStealMouse;
-	cvar_t	*m_pCvarDraw;
-	cvar_t	*m_pCvarDim;
-	cvar_t	*m_pCvarShowNextmap;
-	cvar_t	*m_pCvarShowLoss;
-	cvar_t	*m_pCvarShowSteamId;
-	cvar_t	*m_pCvarColorText;
-	cvar_t	*m_pCvarRDynamicEntLight;
-
-	int m_iFontHeight;
-	int DrawHudNumber(int x, int y, int iFlags, int iNumber, int r, int g, int b );
-	int DrawHudString(int x, int y, const char *szString, int r, int g, int b );
-	int DrawHudStringReverse( int xpos, int ypos, const char *szString, int r, int g, int b );
-	int DrawHudNumberString( int xpos, int ypos, int iNumber, int r, int g, int b );
-	int GetNumWidth(int iNumber, int iFlags);
-	int GetHudCharWidth(int c);
-	int CalculateCharWidth(int c);
-	void GetHudColor( int hudPart, int value, int &r, int &g, int &b );
-	float GetHudTransparency();
-
-private:
 	// the memory for these arrays are allocated in the first call to CHud::VidInit(), when the hud.txt and associated sprites are loaded.
 	// freed in ~CHud()
 	HLHSPRITE *m_rghSprites;	/*[HUD_SPRITE_COUNT]*/			// the sprites loaded from hud.txt
@@ -755,81 +284,6 @@ private:
 	char *m_rgszSpriteNames; /*[HUD_SPRITE_COUNT][MAX_SPRITE_NAME_LENGTH]*/
 
 	struct cvar_s *default_fov;
-public:
-	HLHSPRITE GetSprite( int index ) 
-	{
-		return (index < 0) ? 0 : m_rghSprites[index];
-	}
-	wrect_t& GetSpriteRect( int index )
-	{
-		return m_rgrcRects[index];
-	}
-	int GetSpriteIndex( const char *SpriteName );	// gets a sprite index, for use in the m_rghSprites[] array
-	void AddSprite(client_sprite_t *p);
-
-	CHudAmmo			m_Ammo;
-	CHudHealth			m_Health;
-	CHudSpectator		m_Spectator;
-	CHudGeiger			m_Geiger;
-	CHudBattery			m_Battery;
-	CHudTrain			m_Train;
-	CHudFlashlight		m_Flash;
-	CHudMessage			m_Message;
-	CHudStatusBar		m_StatusBar;
-	CHudDeathNotice		m_DeathNotice;
-	CHudSayText			m_SayText;
-	CHudMenu			m_Menu;
-	CHudAmmoSecondary	m_AmmoSecondary;
-	CHudTextMessage		m_TextMessage;
-	CHudStatusIcons		m_StatusIcons;
-	CHudTimer			m_Timer;
-	CHudScores			m_Scores;
-
-	AgHudGlobal			m_Global;
-	AgHudCountdown		m_Countdown;
-	AgHudCTF			m_CTF;
-	AgHudLocation		m_Location;
-	AgHudLongjump		m_Longjump;
-	AgHudNextmap		m_Nextmap;
-	AgHudPlayerId		m_PlayerId;
-	AgHudSettings		m_Settings;
-	AgHudSuddenDeath	m_SuddenDeath;
-	AgHudTimeout		m_Timeout;
-	AgHudVote			m_Vote;
-
-	void Init( void );
-	void VidInit( void );
-	void Think(void);
-	int Redraw( float flTime, int intermission );
-	int UpdateClientData( client_data_t *cdata, float time );
-
-	CHud() : m_iSpriteCount(0), m_pHudList(NULL) {}
-	~CHud();			// destructor, frees allocated memory
-
-	// user messages
-	int _cdecl MsgFunc_Damage(const char *pszName, int iSize, void *pbuf );
-	int _cdecl MsgFunc_GameMode(const char *pszName, int iSize, void *pbuf );
-	int _cdecl MsgFunc_Logo(const char *pszName,  int iSize, void *pbuf);
-	int _cdecl MsgFunc_ResetHUD(const char *pszName,  int iSize, void *pbuf);
-	void _cdecl MsgFunc_InitHUD( const char *pszName, int iSize, void *pbuf );
-	void _cdecl MsgFunc_ViewMode( const char *pszName, int iSize, void *pbuf );
-	int _cdecl MsgFunc_SetFOV(const char *pszName,  int iSize, void *pbuf);
-	int  _cdecl MsgFunc_Concuss( const char *pszName, int iSize, void *pbuf );
-
-	// Screen information
-	SCREENINFO	m_scrinfo;
-
-	int	m_iWeaponBits;
-	int	m_fPlayerDead;
-	int m_iIntermission;
-
-	// sprite indexes
-	int m_HUD_number_0;
-
-
-	void AddHudElem(CHudBase *p);
-
-	float GetSensitivity();
 };
 
 class TeamFortressViewport;
@@ -843,3 +297,4 @@ extern int g_iUser1;
 extern int g_iUser2;
 extern int g_iUser3;
 
+#endif

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -20,6 +20,7 @@
 #include "cl_util.h"
 #include "parsemsg.h"
 #include "r_efx.h"
+#include "CHudStatusIcons.h"
 
 #define MAX_CLIENTS 32
 
@@ -118,9 +119,9 @@ int CHud :: MsgFunc_Concuss( const char *pszName, int iSize, void *pbuf )
 		float a = 255 * gHUD.GetHudTransparency();
 		gHUD.GetHudColor(0, 0, r, g, b);
 		ScaleColors(r, g, b, a);
-		this->m_StatusIcons.EnableIcon("dmg_concuss", r, g, b);
+		this->m_StatusIcons->EnableIcon("dmg_concuss", r, g, b);
 	}
 	else
-		this->m_StatusIcons.DisableIcon("dmg_concuss");
+		this->m_StatusIcons->DisableIcon("dmg_concuss");
 	return 1;
 }

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -34,14 +34,7 @@ int CHud :: MsgFunc_ResetHUD(const char *pszName, int iSize, void *pbuf )
 	ASSERT( iSize == 0 );
 
 	// clear all hud data
-	HUDLIST *pList = m_pHudList;
-
-	while ( pList )
-	{
-		if ( pList->p )
-			pList->p->Reset();
-		pList = pList->pNext;
-	}
+	for (CHudBase *i : m_HudList) i->Reset();
 
 	// reset sensitivity
 	m_flMouseSensitivity = 0;
@@ -62,14 +55,7 @@ void CHud :: MsgFunc_ViewMode( const char *pszName, int iSize, void *pbuf )
 void CHud :: MsgFunc_InitHUD( const char *pszName, int iSize, void *pbuf )
 {
 	// prepare all hud data
-	HUDLIST *pList = m_pHudList;
-
-	while (pList)
-	{
-		if ( pList->p )
-			pList->p->InitHUDData();
-		pList = pList->pNext;
-	}
+	for (CHudBase *i : m_HudList) i->InitHUDData();
 
 	//Probably not a good place to put this.
 	pBeam = pBeam2 = NULL;

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -44,15 +44,12 @@ extern cvar_t *sensitivity;
 void CHud::Think(void)
 {
 	int newfov;
-	HUDLIST *pList = m_pHudList;
 
 	ResultsThink();
 
-	while (pList)
+	for (CHudBase *i : m_HudList)
 	{
-		if (pList->p->m_iFlags & HUD_ACTIVE)
-			pList->p->Think();
-		pList = pList->pNext;
+		if (i->m_iFlags & HUD_ACTIVE) i->Think();
 	}
 
 	newfov = HUD_GetFOV();
@@ -149,22 +146,18 @@ int CHud :: Redraw( float flTime, int intermission )
 
 	if ( m_pCvarDraw->value )
 	{
-		HUDLIST *pList = m_pHudList;
-
-		while (pList)
+		for (CHudBase *i : m_HudList)
 		{
-			if ( !intermission )
+			if (!intermission)
 			{
-				if ( (pList->p->m_iFlags & HUD_ACTIVE) && !(m_iHideHUDDisplay & HIDEHUD_ALL) )
-					pList->p->Draw(flTime);
+				if ((i->m_iFlags & HUD_ACTIVE) && !(m_iHideHUDDisplay & HIDEHUD_ALL))
+					i->Draw(flTime);
 			}
 			else
 			{  // it's an intermission,  so only draw hud elements that are set to draw during intermissions
-				if ( pList->p->m_iFlags & HUD_INTERMISSION )
-					pList->p->Draw( flTime );
+				if (i->m_iFlags & HUD_INTERMISSION)
+					i->Draw(flTime);
 			}
-
-			pList = pList->pNext;
 		}
 	}
 

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -76,12 +76,6 @@ void CHud::Think(void)
 		m_flMouseSensitivity = sensitivity->value * ((float)newfov / (float)default_fov->value) * CVAR_GET_FLOAT("zoom_sensitivity_ratio");
 	}
 
-	// think about default fov
-	if ( m_iFOV == 0 )
-	{  // only let players adjust up in fov,  and only if they are not overriden by something else
-		m_iFOV = max( default_fov->value, 90 );  
-	}
-
 	// Refresh bunnyhop
 	g_bBunnyHop = m_pCvarBunnyHop->value != 0.0;
 }

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -28,6 +28,7 @@ extern "C"
 #include <ctype.h>
 
 #include "vgui_TeamFortressViewport.h"
+#include "CHudSpectator.h"
 
 
 extern "C" 
@@ -415,25 +416,25 @@ void IN_RightUp(void) {KeyUp(&in_right);}
 void IN_ForwardDown(void)
 {
 	KeyDown(&in_forward);
-	gHUD.m_Spectator.HandleButtonsDown( IN_FORWARD );
+	gHUD.m_Spectator->HandleButtonsDown( IN_FORWARD );
 }
 
 void IN_ForwardUp(void)
 {
 	KeyUp(&in_forward);
-	gHUD.m_Spectator.HandleButtonsUp( IN_FORWARD );
+	gHUD.m_Spectator->HandleButtonsUp( IN_FORWARD );
 }
 
 void IN_BackDown(void)
 {
 	KeyDown(&in_back);
-	gHUD.m_Spectator.HandleButtonsDown( IN_BACK );
+	gHUD.m_Spectator->HandleButtonsDown( IN_BACK );
 }
 
 void IN_BackUp(void)
 {
 	KeyUp(&in_back);
-	gHUD.m_Spectator.HandleButtonsUp( IN_BACK );
+	gHUD.m_Spectator->HandleButtonsUp( IN_BACK );
 }
 void IN_LookupDown(void) {KeyDown(&in_lookup);}
 void IN_LookupUp(void) {KeyUp(&in_lookup);}
@@ -442,25 +443,25 @@ void IN_LookdownUp(void) {KeyUp(&in_lookdown);}
 void IN_MoveleftDown(void)
 {
 	KeyDown(&in_moveleft);
-	gHUD.m_Spectator.HandleButtonsDown( IN_MOVELEFT );
+	gHUD.m_Spectator->HandleButtonsDown( IN_MOVELEFT );
 }
 
 void IN_MoveleftUp(void)
 {
 	KeyUp(&in_moveleft);
-	gHUD.m_Spectator.HandleButtonsUp( IN_MOVELEFT );
+	gHUD.m_Spectator->HandleButtonsUp( IN_MOVELEFT );
 }
 
 void IN_MoverightDown(void)
 {
 	KeyDown(&in_moveright);
-	gHUD.m_Spectator.HandleButtonsDown( IN_MOVERIGHT );
+	gHUD.m_Spectator->HandleButtonsDown( IN_MOVERIGHT );
 }
 
 void IN_MoverightUp(void)
 {
 	KeyUp(&in_moveright);
-	gHUD.m_Spectator.HandleButtonsUp( IN_MOVERIGHT );
+	gHUD.m_Spectator->HandleButtonsUp( IN_MOVERIGHT );
 }
 void IN_SpeedDown(void) {KeyDown(&in_speed);}
 void IN_SpeedUp(void) {KeyUp(&in_speed);}
@@ -473,20 +474,20 @@ extern void __CmdFunc_InputPlayerSpecial(void);
 void IN_Attack2Down(void) 
 {
 	KeyDown(&in_attack2);
-	gHUD.m_Spectator.HandleButtonsDown( IN_ATTACK2 );
+	gHUD.m_Spectator->HandleButtonsDown( IN_ATTACK2 );
 }
 
 void IN_Attack2Up(void) {KeyUp(&in_attack2);}
 void IN_UseDown (void)
 {
 	KeyDown(&in_use);
-	gHUD.m_Spectator.HandleButtonsDown( IN_USE );
+	gHUD.m_Spectator->HandleButtonsDown( IN_USE );
 }
 void IN_UseUp (void) {KeyUp(&in_use);}
 void IN_JumpDown (void)
 {
 	KeyDown(&in_jump);
-	gHUD.m_Spectator.HandleButtonsDown( IN_JUMP );
+	gHUD.m_Spectator->HandleButtonsDown( IN_JUMP );
 }
 void IN_JumpUp (void) {KeyUp(&in_jump);}
 void IN_LongJumpDown(void) { KeyDown(&in_longjump); }
@@ -496,7 +497,7 @@ void IN_BunnyHopUp(void) { KeyUp(&in_bunnyhop); }
 void IN_DuckDown(void)
 {
 	KeyDown(&in_duck);
-	gHUD.m_Spectator.HandleButtonsDown( IN_DUCK );
+	gHUD.m_Spectator->HandleButtonsDown( IN_DUCK );
 }
 void IN_DuckUp(void) {KeyUp(&in_duck);}
 void IN_ReloadDown(void) {KeyDown(&in_reload);}
@@ -509,7 +510,7 @@ void IN_GraphUp(void) {KeyUp(&in_graph);}
 void IN_AttackDown(void)
 {
 	KeyDown( &in_attack );
-	gHUD.m_Spectator.HandleButtonsDown( IN_ATTACK );
+	gHUD.m_Spectator->HandleButtonsDown( IN_ATTACK );
 }
 
 void IN_AttackUp(void)
@@ -797,7 +798,7 @@ Returns 1 if health is <= 0
 */
 int CL_IsDead( void )
 {
-	return ( gHUD.m_Health.m_iHealth <= 0 ) ? 1 : 0;
+	return ( gHUD.m_Health->m_iHealth <= 0 ) ? 1 : 0;
 }
 
 /*

--- a/cl_dll/msvc/client.vcxproj
+++ b/cl_dll/msvc/client.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{BE1A2217-86F6-4A6F-8AE9-86B4796C80A5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>client</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/cl_dll/msvc/client.vcxproj
+++ b/cl_dll/msvc/client.vcxproj
@@ -14,19 +14,19 @@
     <ProjectGuid>{BE1A2217-86F6-4A6F-8AE9-86B4796C80A5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>client</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -180,22 +180,23 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClCompile Include="..\aghudtimeout.cpp" />
     <ClCompile Include="..\aghudvote.cpp" />
     <ClCompile Include="..\aglocation.cpp" />
-    <ClCompile Include="..\ammo.cpp" />
+    <ClCompile Include="..\CHudAmmo.cpp" />
     <ClCompile Include="..\ammohistory.cpp" />
-    <ClCompile Include="..\ammo_secondary.cpp" />
-    <ClCompile Include="..\battery.cpp" />
+    <ClCompile Include="..\CHudAmmoSecondary.cpp" />
+    <ClCompile Include="..\CHudBattery.cpp" />
     <ClCompile Include="..\cdll_int.cpp" />
+    <ClCompile Include="..\CHudBase.cpp" />
     <ClCompile Include="..\com_weapons.cpp" />
-    <ClCompile Include="..\death.cpp" />
+    <ClCompile Include="..\CHudDeathNotice.cpp" />
     <ClCompile Include="..\demo.cpp" />
     <ClCompile Include="..\entity.cpp" />
     <ClCompile Include="..\events.cpp" />
     <ClCompile Include="..\ev_common.cpp" />
     <ClCompile Include="..\ev_hldm.cpp" />
-    <ClCompile Include="..\flashlight.cpp" />
+    <ClCompile Include="..\CHudFlashlight.cpp" />
     <ClCompile Include="..\GameStudioModelRenderer.cpp" />
-    <ClCompile Include="..\geiger.cpp" />
-    <ClCompile Include="..\health.cpp" />
+    <ClCompile Include="..\CHudGeiger.cpp" />
+    <ClCompile Include="..\CHudHealth.cpp" />
     <ClCompile Include="..\hl\hl_baseentity.cpp" />
     <ClCompile Include="..\hl\hl_events.cpp" />
     <ClCompile Include="..\hl\hl_objects.cpp" />
@@ -203,17 +204,17 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClCompile Include="..\hud.cpp" />
     <ClCompile Include="..\hud_msg.cpp" />
     <ClCompile Include="..\hud_redraw.cpp" />
-    <ClCompile Include="..\hud_scores.cpp" />
+    <ClCompile Include="..\CHudScores.cpp" />
     <ClCompile Include="..\hud_servers.cpp" />
-    <ClCompile Include="..\hud_spectator.cpp" />
-    <ClCompile Include="..\hud_timer.cpp" />
+    <ClCompile Include="..\CHudSpectator.cpp" />
+    <ClCompile Include="..\CHudTimer.cpp" />
     <ClCompile Include="..\hud_update.cpp" />
     <ClCompile Include="..\input.cpp" />
     <ClCompile Include="..\inputw32.cpp" />
     <ClCompile Include="..\in_camera.cpp" />
     <ClCompile Include="..\jpeg\jpge.cpp" />
-    <ClCompile Include="..\menu.cpp" />
-    <ClCompile Include="..\message.cpp" />
+    <ClCompile Include="..\CHudMenu.cpp" />
+    <ClCompile Include="..\CHudMessage.cpp" />
     <ClCompile Include="..\net.cpp" />
     <ClCompile Include="..\overview.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -221,14 +222,14 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     </ClCompile>
     <ClCompile Include="..\parsemsg.cpp" />
     <ClCompile Include="..\results.cpp" />
-    <ClCompile Include="..\saytext.cpp" />
-    <ClCompile Include="..\statusbar.cpp" />
-    <ClCompile Include="..\status_icons.cpp" />
+    <ClCompile Include="..\CHudSayText.cpp" />
+    <ClCompile Include="..\CHudStatusBar.cpp" />
+    <ClCompile Include="..\CHudStatusIcons.cpp" />
     <ClCompile Include="..\StudioModelRenderer.cpp" />
     <ClCompile Include="..\studio_util.cpp" />
     <ClCompile Include="..\svc_messages.cpp" />
-    <ClCompile Include="..\text_message.cpp" />
-    <ClCompile Include="..\train.cpp" />
+    <ClCompile Include="..\CHudTextMessage.cpp" />
+    <ClCompile Include="..\CHudTrain.cpp" />
     <ClCompile Include="..\tri.cpp" />
     <ClCompile Include="..\util.cpp" />
     <ClCompile Include="..\vgui_ClassMenu.cpp" />
@@ -280,6 +281,22 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClInclude Include="..\ammo.h" />
     <ClInclude Include="..\ammohistory.h" />
     <ClInclude Include="..\camera.h" />
+    <ClInclude Include="..\CHudAmmo.h" />
+    <ClInclude Include="..\CHudAmmoSecondary.h" />
+    <ClInclude Include="..\CHudBase.h" />
+    <ClInclude Include="..\CHudBattery.h" />
+    <ClInclude Include="..\CHudDeathNotice.h" />
+    <ClInclude Include="..\CHudFlashlight.h" />
+    <ClInclude Include="..\CHudGeiger.h" />
+    <ClInclude Include="..\CHudMenu.h" />
+    <ClInclude Include="..\CHudMessage.h" />
+    <ClInclude Include="..\CHudSayText.h" />
+    <ClInclude Include="..\CHudScores.h" />
+    <ClInclude Include="..\CHudStatusBar.h" />
+    <ClInclude Include="..\CHudStatusIcons.h" />
+    <ClInclude Include="..\CHudTextMessage.h" />
+    <ClInclude Include="..\CHudTimer.h" />
+    <ClInclude Include="..\CHudTrain.h" />
     <ClInclude Include="..\cl_dll.h" />
     <ClInclude Include="..\cl_util.h" />
     <ClInclude Include="..\com_weapons.h" />
@@ -287,12 +304,12 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClInclude Include="..\eventscripts.h" />
     <ClInclude Include="..\ev_hldm.h" />
     <ClInclude Include="..\GameStudioModelRenderer.h" />
-    <ClInclude Include="..\health.h" />
+    <ClInclude Include="..\CHudHealth.h" />
     <ClInclude Include="..\hud.h" />
     <ClInclude Include="..\hud_iface.h" />
     <ClInclude Include="..\hud_servers.h" />
     <ClInclude Include="..\hud_servers_priv.h" />
-    <ClInclude Include="..\hud_spectator.h" />
+    <ClInclude Include="..\CHudSpectator.h" />
     <ClInclude Include="..\in_defs.h" />
     <ClInclude Include="..\jpeg\jpge.h" />
     <ClInclude Include="..\kbutton.h" />

--- a/cl_dll/msvc/client.vcxproj
+++ b/cl_dll/msvc/client.vcxproj
@@ -201,7 +201,7 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClCompile Include="..\hl\hl_events.cpp" />
     <ClCompile Include="..\hl\hl_objects.cpp" />
     <ClCompile Include="..\hl\hl_weapons.cpp" />
-    <ClCompile Include="..\hud.cpp" />
+    <ClCompile Include="..\CHud.cpp" />
     <ClCompile Include="..\hud_msg.cpp" />
     <ClCompile Include="..\hud_redraw.cpp" />
     <ClCompile Include="..\CHudScores.cpp" />

--- a/cl_dll/msvc/client.vcxproj
+++ b/cl_dll/msvc/client.vcxproj
@@ -14,19 +14,19 @@
     <ProjectGuid>{BE1A2217-86F6-4A6F-8AE9-86B4796C80A5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>client</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/cl_dll/msvc/client.vcxproj.filters
+++ b/cl_dll/msvc/client.vcxproj.filters
@@ -43,9 +43,6 @@
     <ClCompile Include="..\GameStudioModelRenderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\hud.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\hud_msg.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -350,6 +347,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\CHudSpectator.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHud.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/cl_dll/msvc/client.vcxproj.filters
+++ b/cl_dll/msvc/client.vcxproj.filters
@@ -19,25 +19,13 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\ammo.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\ammo_secondary.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\ammohistory.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\battery.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\cdll_int.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\com_weapons.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\death.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\demo.cpp">
@@ -52,16 +40,7 @@
     <ClCompile Include="..\events.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\flashlight.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\GameStudioModelRenderer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\geiger.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\health.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\hud.cpp">
@@ -76,9 +55,6 @@
     <ClCompile Include="..\hud_servers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\hud_spectator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\hud_update.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -89,12 +65,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\inputw32.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\menu.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\message.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\overview.cpp">
@@ -112,25 +82,10 @@
     <ClCompile Include="..\..\pm_shared\pm_shared.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\saytext.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\status_icons.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\statusbar.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\studio_util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\StudioModelRenderer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\text_message.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\train.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\tri.cpp">
@@ -271,9 +226,6 @@
     <ClCompile Include="..\..\dlls\path.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\hud_timer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\net.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -346,7 +298,58 @@
     <ClCompile Include="..\aghudlocation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\hud_scores.cpp">
+    <ClCompile Include="..\CHudBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudAmmo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudAmmoSecondary.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudHealth.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudGeiger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudTrain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudStatusBar.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudDeathNotice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudMenu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudSayText.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudBattery.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudFlashlight.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudTextMessage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudMessage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudTimer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudScores.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudStatusIcons.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CHudSpectator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -378,9 +381,6 @@
     <ClInclude Include="..\GameStudioModelRenderer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\health.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\hud.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -391,9 +391,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\hud_servers_priv.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\hud_spectator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\in_defs.h">
@@ -547,6 +544,60 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\aghudlocation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudSpectator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudAmmo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudAmmoSecondary.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudHealth.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudGeiger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudTrain.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudStatusBar.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudDeathNotice.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudMenu.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudSayText.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudBattery.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudFlashlight.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudTextMessage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudMessage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudTimer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudScores.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CHudStatusIcons.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cl_dll/svc_messages.cpp
+++ b/cl_dll/svc_messages.cpp
@@ -20,6 +20,7 @@
 #include "vgui_TeamFortressViewport.h"
 #include "vgui_ScorePanel.h"
 #include "pcre/pcre.h"
+#include "CHudTimer.h"
 
 #define MAX_CMD_LINE	1024
 
@@ -218,7 +219,7 @@ void SvcPrint(void)
 		if (!strncmp(str, "\"mp_timelimit\" changed to \"", 27) ||
 			!strncmp(str, "\"amx_nextmap\" changed to \"", 26))
 		{
-			gHUD.m_Timer.DoResync();
+			gHUD.m_Timer->DoResync();
 		}
 		else if (gViewPort && gViewPort->m_pScoreBoard && gViewPort->m_pScoreBoard->m_iStatusRequestState != STATUS_REQUEST_IDLE)
 		{

--- a/cl_dll/tri.cpp
+++ b/cl_dll/tri.cpp
@@ -16,6 +16,7 @@
 #include "entity_state.h"
 #include "cl_entity.h"
 #include "triangleapi.h"
+#include "CHudSpectator.h"
 
 #define DLLEXPORT __declspec( dllexport )
 
@@ -101,7 +102,7 @@ Non-transparent triangles-- add them here
 void DLLEXPORT HUD_DrawNormalTriangles( void )
 {
 
-	gHUD.m_Spectator.DrawOverview();
+	gHUD.m_Spectator->DrawOverview();
 	
 #if defined( TEST_IT )
 //	Draw_Triangles();

--- a/cl_dll/util_vector.h
+++ b/cl_dll/util_vector.h
@@ -15,11 +15,13 @@
 //  Vector.h
 // A subset of the extdll.h in the project HL Entity DLL
 //
+#ifndef UTIL_VECTOR_H
+#define UTIL_VECTOR_H
 
 // Misc C-runtime library headers
-#include "STDIO.H"
-#include "STDLIB.H"
-#include "MATH.H"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef int	func_t;					//
@@ -119,3 +121,5 @@ inline float DotProduct(const Vector& a, const Vector& b) { return(a.x*b.x+a.y*b
 inline Vector CrossProduct(const Vector& a, const Vector& b) { return Vector( a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x ); }
 
 #define vec3_t Vector
+
+#endif

--- a/cl_dll/vgui_ClassMenu.cpp
+++ b/cl_dll/vgui_ClassMenu.cpp
@@ -33,6 +33,7 @@
 #include "vgui_int.h"
 #include "vgui_TeamFortressViewport.h"
 #include "vgui_ServerBrowser.h"
+#include "CHudTextMessage.h"
 
 // Class Menu Dimensions
 #define CLASSMENU_TITLE_X				XRES(40)
@@ -83,7 +84,7 @@ CClassMenuPanel::CClassMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide
 	pSchemes->getBgColor( hTitleScheme, r, g, b, a );
 	pLabel->setBgColor( r, g, b, a );
 	pLabel->setContentAlignment( vgui::Label::a_west );
-	pLabel->setText(gHUD.m_TextMessage.BufferedLocaliseTextString("#Title_SelectYourClass"));
+	pLabel->setText(gHUD.m_TextMessage->BufferedLocaliseTextString("#Title_SelectYourClass"));
 
 	// Create the Scroll panel
 	m_pScrollPanel = new CTFScrollPanel( CLASSMENU_WINDOW_X, CLASSMENU_WINDOW_Y, CLASSMENU_WINDOW_SIZE_X, CLASSMENU_WINDOW_SIZE_Y );
@@ -188,7 +189,7 @@ CClassMenuPanel::CClassMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide
 		}
 
 		// Create the Player count string
-		gHUD.m_TextMessage.LocaliseTextString( "#Title_CurrentlyOnYourTeam", m_sPlayersOnTeamString, STRLENMAX_PLAYERSONTEAM );
+		gHUD.m_TextMessage->LocaliseTextString( "#Title_CurrentlyOnYourTeam", m_sPlayersOnTeamString, STRLENMAX_PLAYERSONTEAM );
 		m_pPlayers[i] = new Label( "", textOffs, CLASSMENU_WINDOW_PLAYERS_Y );
 		m_pPlayers[i]->setParent( m_pClassInfoPanel[i] );
 		m_pPlayers[i]->setBgColor( 0, 0, 0, 255 );
@@ -241,7 +242,7 @@ CClassMenuPanel::CClassMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide
 	}
 
 	// Create the Cancel button
-	m_pCancelButton = new CommandButton( gHUD.m_TextMessage.BufferedLocaliseTextString( "#Menu_Cancel" ), CLASSMENU_TOPLEFT_BUTTON_X, 0, CLASSMENU_BUTTON_SIZE_X, CLASSMENU_BUTTON_SIZE_Y);
+	m_pCancelButton = new CommandButton( gHUD.m_TextMessage->BufferedLocaliseTextString( "#Menu_Cancel" ), CLASSMENU_TOPLEFT_BUTTON_X, 0, CLASSMENU_BUTTON_SIZE_X, CLASSMENU_BUTTON_SIZE_Y);
 	m_pCancelButton->setParent( this );
 	m_pCancelButton->addActionSignal( new CMenuHandler_TextWindow(HIDE_TEXTWINDOW) );
 

--- a/cl_dll/vgui_MOTDWindow.cpp
+++ b/cl_dll/vgui_MOTDWindow.cpp
@@ -31,6 +31,7 @@
 #include "vgui_int.h"
 #include "vgui_TeamFortressViewport.h"
 #include "vgui_ServerBrowser.h"
+#include "CHudTextMessage.h"
 
 #define MOTD_TITLE_X		XRES(16)
 #define MOTD_TITLE_Y		YRES(16)

--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -29,6 +29,8 @@
 #include "..\game_shared\vgui_helpers.h"
 #include "..\game_shared\vgui_loadtga.h"
 #include "vgui_SpectatorPanel.h"
+#include "CHudTextMessage.h"
+#include "CHudTimer.h"
 
 hud_player_info_t	g_PlayerInfoList[MAX_PLAYERS + 1];	// player info from the engine
 extra_player_info_t	g_PlayerExtraInfo[MAX_PLAYERS + 1];	// additional player info sent directly to the client dll
@@ -436,7 +438,7 @@ void ScorePanel::Update()
 
 	// Set next map
 	char temp[MAX_MAP_NAME + 10];
-	const char* nextmap = gHUD.m_Timer.GetNextmap();
+	const char* nextmap = gHUD.m_Timer->GetNextmap();
 	if (nextmap[0])
 	{
 		sprintf_s(temp, sizeof(temp), "nextmap: %s", nextmap);
@@ -1057,7 +1059,7 @@ void ScorePanel::mousePressed(MouseCode code, Panel* panel)
 					sprintf( string1, CHudTextMessage::BufferedLocaliseTextString( "#Unmuted" ), pl_info->name );
 					sprintf( string, "%c** %s\n", HUD_PRINTTALK, string1 );
 
-					gHUD.m_TextMessage.MsgFunc_TextMsg(NULL, strlen(string)+1, string );
+					gHUD.m_TextMessage->MsgFunc_TextMsg(NULL, strlen(string)+1, string );
 				}
 				else
 				{
@@ -1071,7 +1073,7 @@ void ScorePanel::mousePressed(MouseCode code, Panel* panel)
 					sprintf( string2, CHudTextMessage::BufferedLocaliseTextString( "#No_longer_hear_that_player" ) );
 					sprintf( string, "%c** %s %s\n", HUD_PRINTTALK, string1, string2 );
 
-					gHUD.m_TextMessage.MsgFunc_TextMsg(NULL, strlen(string)+1, string );
+					gHUD.m_TextMessage->MsgFunc_TextMsg(NULL, strlen(string)+1, string );
 				}
 			}
 		}

--- a/cl_dll/vgui_SpectatorPanel.cpp
+++ b/cl_dll/vgui_SpectatorPanel.cpp
@@ -18,6 +18,8 @@
 #include "vgui_TeamFortressViewport.h"
 #include "vgui_SpectatorPanel.h"
 #include "vgui_scorepanel.h"
+#include "CHudSpectator.h"
+#include "CHudTextMessage.h"
 
 #define PANEL_HEIGHT 32
 
@@ -51,10 +53,10 @@ void SpectatorPanel::ActionSignal(int cmd)
 		case SPECTATOR_PANEL_CMD_OPTIONS :		gViewPort->ShowCommandMenu( gViewPort->m_SpectatorOptionsMenu );
 												break;
 
-		case SPECTATOR_PANEL_CMD_NEXTPLAYER :	gHUD.m_Spectator.FindNextPlayer(true);
+		case SPECTATOR_PANEL_CMD_NEXTPLAYER :	gHUD.m_Spectator->FindNextPlayer(true);
 												break;
 
-		case SPECTATOR_PANEL_CMD_PREVPLAYER :	gHUD.m_Spectator.FindNextPlayer(false);
+		case SPECTATOR_PANEL_CMD_PREVPLAYER :	gHUD.m_Spectator->FindNextPlayer(false);
 												break;
 
 		case SPECTATOR_PANEL_CMD_HIDEMENU	:	ShowMenu(false); 
@@ -63,8 +65,8 @@ void SpectatorPanel::ActionSignal(int cmd)
 		case SPECTATOR_PANEL_CMD_CAMERA :		gViewPort->ShowCommandMenu( gViewPort->m_SpectatorCameraMenu );
 												break;
 
-		case SPECTATOR_PANEL_CMD_TOGGLE_INSET : gHUD.m_Spectator.SetModes( -1, 
-													gHUD.m_Spectator.ToggleInset(false) );
+		case SPECTATOR_PANEL_CMD_TOGGLE_INSET : gHUD.m_Spectator->SetModes( -1, 
+													gHUD.m_Spectator->ToggleInset(false) );
 												break;
 
 		default : 	gEngfuncs.Con_DPrintf("Unknown SpectatorPanel ActionSingal %i.\n",cmd); break;
@@ -235,7 +237,7 @@ void SpectatorPanel::ShowMenu(bool isVisible)
 			_snprintf( string, sizeof( string ) - 1, "%c%s", HUD_PRINTCENTER, CHudTextMessage::BufferedLocaliseTextString( "#Spec_Duck" ) );
 			string[ sizeof( string ) - 1 ] = '\0';
 
-			gHUD.m_TextMessage.MsgFunc_TextMsg( NULL, strlen( string ) + 1, string );
+			gHUD.m_TextMessage->MsgFunc_TextMsg( NULL, strlen( string ) + 1, string );
 		}
 	}
 
@@ -277,10 +279,10 @@ const char *GetSpectatorLabel ( int iMode )
 
 void SpectatorPanel::EnableInsetView(bool isEnabled)
 {
-	int x = gHUD.m_Spectator.m_OverviewData.insetWindowX;
-	int y = gHUD.m_Spectator.m_OverviewData.insetWindowY;
-	int wide = gHUD.m_Spectator.m_OverviewData.insetWindowWidth;
-	int tall = gHUD.m_Spectator.m_OverviewData.insetWindowHeight;
+	int x = gHUD.m_Spectator->m_OverviewData.insetWindowX;
+	int y = gHUD.m_Spectator->m_OverviewData.insetWindowY;
+	int wide = gHUD.m_Spectator->m_OverviewData.insetWindowWidth;
+	int tall = gHUD.m_Spectator->m_OverviewData.insetWindowHeight;
 	int offset = x + wide + 2;
 	
 	if ( isEnabled )
@@ -331,11 +333,11 @@ void SpectatorPanel::Update()
 	//int offset,j;
 
 	//if ( m_insetVisible )
-	//	offset = gHUD.m_Spectator.m_OverviewData.insetWindowX + gHUD.m_Spectator.m_OverviewData.insetWindowWidth + 2;
+	//	offset = gHUD.m_Spectator->m_OverviewData.insetWindowX + gHUD.m_Spectator->m_OverviewData.insetWindowWidth + 2;
 	//else
 	//	offset = 0;
 
-	//bool visible = gHUD.m_Spectator.m_drawstatus->value != 0;
+	//bool visible = gHUD.m_Spectator->m_drawstatus->value != 0;
 
 	//m_ExtraInfo->setVisible( visible );
 	//m_TimerImage->setVisible( visible );

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -55,6 +55,9 @@
 #include "vgui_ScorePanel.h"
 #include "vgui_SpectatorPanel.h"
 
+#include "CHudTextMessage.h"
+#include "CHudSpectator.h"
+
 extern int g_iVisibleMouse;
 class CCommandMenu;
 int g_iPlayerClass;
@@ -678,9 +681,9 @@ try
 	// First, read in the localisation strings
 
 	// Detpack strings
-	gHUD.m_TextMessage.LocaliseTextString( "#DetpackSet_For5Seconds",   m_sDetpackStrings[0], MAX_BUTTON_SIZE );
-	gHUD.m_TextMessage.LocaliseTextString( "#DetpackSet_For20Seconds",   m_sDetpackStrings[1], MAX_BUTTON_SIZE );
-	gHUD.m_TextMessage.LocaliseTextString( "#DetpackSet_For50Seconds",   m_sDetpackStrings[2], MAX_BUTTON_SIZE );
+	gHUD.m_TextMessage->LocaliseTextString( "#DetpackSet_For5Seconds",   m_sDetpackStrings[0], MAX_BUTTON_SIZE );
+	gHUD.m_TextMessage->LocaliseTextString( "#DetpackSet_For20Seconds",   m_sDetpackStrings[1], MAX_BUTTON_SIZE );
+	gHUD.m_TextMessage->LocaliseTextString( "#DetpackSet_For50Seconds",   m_sDetpackStrings[2], MAX_BUTTON_SIZE );
 
 	// Now start parsing the menu structure
 	m_pCurrentCommandMenu = m_pCommandMenus[newIndex];
@@ -958,7 +961,7 @@ CommandButton *TeamFortressViewport::CreateCustomButton( char *pButtonText, char
 
 		// Auto Assign button
 		sprintf(sz, "jointeam %d", MAX_TEAMS_IN_MENU + 1);
-		m_pTeamButtons[MAX_TEAMS_IN_MENU] = new TeamButton(MAX_TEAMS_IN_MENU + 1, gHUD.m_TextMessage.BufferedLocaliseTextString( "Auto Assign" ), 0, BUTTON_SIZE_Y, CMENU_SIZE_X, BUTTON_SIZE_Y);
+		m_pTeamButtons[MAX_TEAMS_IN_MENU] = new TeamButton(MAX_TEAMS_IN_MENU + 1, gHUD.m_TextMessage->BufferedLocaliseTextString( "Auto Assign" ), 0, BUTTON_SIZE_Y, CMENU_SIZE_X, BUTTON_SIZE_Y);
 		m_pTeamButtons[MAX_TEAMS_IN_MENU]->addActionSignal(new CMenuHandler_StringCommand( sz ));
 		pMenu->AddButton( m_pTeamButtons[MAX_TEAMS_IN_MENU] );
 
@@ -1399,7 +1402,7 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 		int player = 0;
 
 		// check if spectator combinations are still valid
-		gHUD.m_Spectator.CheckSettings();
+		gHUD.m_Spectator->CheckSettings();
 
 		if ( !m_pSpectatorPanel->isVisible() )
 		{
@@ -1409,7 +1412,7 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 			_snprintf( tempString, sizeof( tempString ) - 1, "%c%s", HUD_PRINTCENTER, CHudTextMessage::BufferedLocaliseTextString( "#Spec_Duck" ) );
 			tempString[ sizeof( tempString ) - 1 ] = '\0';
 
-			gHUD.m_TextMessage.MsgFunc_TextMsg( NULL, strlen( tempString ) + 1, tempString );
+			gHUD.m_TextMessage->MsgFunc_TextMsg( NULL, strlen( tempString ) + 1, tempString );
 		}
 
 		sprintf(bottomText, "#Spec_Mode%d", g_iUser1 );
@@ -1425,7 +1428,7 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 		}
 
 		// special case in free map and inset off, don't show names
-		if ((g_iUser1 != OBS_MAP_FREE && g_iUser1 != OBS_ROAMING || gHUD.m_Spectator.m_pip->value) && player && g_PlayerInfoList[player].name)
+		if ((g_iUser1 != OBS_MAP_FREE && g_iUser1 != OBS_ROAMING || gHUD.m_Spectator->m_pip->value) && player && g_PlayerInfoList[player].name)
 		{
 			if (gHUD.m_pCvarColorText->value == 0)
 				strncpy(bottomText, g_PlayerInfoList[player].name, sizeof(bottomText) - 1);
@@ -1452,7 +1455,7 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 		m_pSpectatorPanel->m_BottomMainLabel->setFgColor(r, g, b, 0);
 
 		// add sting auto if we are in auto directed mode
-		if ( gHUD.m_Spectator.m_autoDirector->value )
+		if ( gHUD.m_Spectator->m_autoDirector->value )
 		{
 			char tempString[128];
 			sprintf(tempString, "#Spec_Auto %s", helpString2);
@@ -1468,7 +1471,7 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 		if ( gEngfuncs.IsSpectateOnly() )
 		{
 			// in HLTV mode show number of spectators
-			_snprintf( szText, 63, "%s: %d", CHudTextMessage::BufferedLocaliseTextString( "#Spectators" ), gHUD.m_Spectator.m_iSpectatorNumber );
+			_snprintf( szText, 63, "%s: %d", CHudTextMessage::BufferedLocaliseTextString( "#Spectators" ), gHUD.m_Spectator->m_iSpectatorNumber );
 		}
 		else
 		{
@@ -2169,7 +2172,7 @@ int TeamFortressViewport::MsgFunc_TeamNames(const char *pszName, int iSize, void
 
 		int teamNum = i + 1;
 
-		gHUD.m_TextMessage.LocaliseTextString( READ_STRING(), m_sTeamNames[teamNum], MAX_TEAM_NAME );
+		gHUD.m_TextMessage->LocaliseTextString( READ_STRING(), m_sTeamNames[teamNum], MAX_TEAM_NAME );
 
 		// Parse the model and remove any %'s
 		for (char *c = m_sTeamNames[teamNum]; *c != 0; c++)

--- a/cl_dll/vgui_TeamFortressViewport.h
+++ b/cl_dll/vgui_TeamFortressViewport.h
@@ -28,6 +28,8 @@
 #include<VGUI_ScrollBar.h>
 #include<VGUI_Slider.h>
 
+#include "CHudHealth.h"
+
 // custom scheme handling
 #include "vgui_SchemeManager.h"
 
@@ -1684,23 +1686,23 @@ public:
 
 		if (gHUD.m_pCvarDim->value == 0)
 			a = MIN_ALPHA + ALPHA_POINTS_MAX;
-		else if (gHUD.m_Health.m_fFade > 0)
+		else if (gHUD.m_Health->m_fFade > 0)
 		{
 			// Fade the health number back to dim
-			gHUD.m_Health.m_fFade -= (gHUD.m_flTimeDelta * 20);
-			if (gHUD.m_Health.m_fFade <= 0)
-				gHUD.m_Health.m_fFade = 0;
-			a = MIN_ALPHA + (gHUD.m_Health.m_fFade/FADE_TIME) * ALPHA_POINTS_FLASH;
+			gHUD.m_Health->m_fFade -= (gHUD.m_flTimeDelta * 20);
+			if (gHUD.m_Health->m_fFade <= 0)
+				gHUD.m_Health->m_fFade = 0;
+			a = MIN_ALPHA + (gHUD.m_Health->m_fFade/HUD_FADE_TIME) * ALPHA_POINTS_FLASH;
 		}
 		else
 			a = MIN_ALPHA;
 
 		// If health is getting low, make it bright red
-		if (gHUD.m_Health.m_iHealth <= 15)
+		if (gHUD.m_Health->m_iHealth <= 15)
 			a = 255;
 
 		a *= gHUD.GetHudTransparency();
-		gHUD.GetHudColor(1, gHUD.m_Health.m_iHealth, r, g, b);
+		gHUD.GetHudColor(1, gHUD.m_Health->m_iHealth, r, g, b);
 		ScaleColors(r, g, b, a );
 
 		int iXSize,iYSize, iXPos, iYPos;
@@ -1708,7 +1710,7 @@ public:
 		m_pHealthTGA->getPos(iXPos, iYPos);
 
 		// Paint the player's health
-		int x = gHUD.DrawHudNumber( iXPos + iXSize + 5, iYPos + 5, DHN_3DIGITS | DHN_DRAWZERO, gHUD.m_Health.m_iHealth, r, g, b);
+		int x = gHUD.DrawHudNumber( iXPos + iXSize + 5, iYPos + 5, DHN_3DIGITS | DHN_DRAWZERO, gHUD.m_Health->m_iHealth, r, g, b);
 
 		// Draw the vertical line
 		int HealthWidth = gHUD.GetSpriteRect(gHUD.m_HUD_number_0).right - gHUD.GetSpriteRect(gHUD.m_HUD_number_0).left;

--- a/cl_dll/vgui_teammenu.cpp
+++ b/cl_dll/vgui_teammenu.cpp
@@ -24,6 +24,7 @@
 #include "hud.h"
 #include "cl_util.h"
 #include "vgui_TeamFortressViewport.h"
+#include "CHudTextMessage.h"
 
 // Team Menu Dimensions
 #define TEAMMENU_TITLE_X				XRES(40)
@@ -69,7 +70,7 @@ CTeamMenuPanel::CTeamMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide,i
 	pSchemes->getBgColor( hTitleScheme, r, g, b, a );
 	pLabel->setBgColor( r, g, b, a );
 	pLabel->setContentAlignment( vgui::Label::a_west );
-	pLabel->setText(gHUD.m_TextMessage.BufferedLocaliseTextString("Select Your Team"));
+	pLabel->setText(gHUD.m_TextMessage->BufferedLocaliseTextString("Select Your Team"));
 
 	// Create the Info Window
 	m_pTeamWindow  = new CTransparentPanel( 255, TEAMMENU_WINDOW_X, TEAMMENU_WINDOW_Y, TEAMMENU_WINDOW_SIZE_X, TEAMMENU_WINDOW_SIZE_Y );
@@ -100,7 +101,7 @@ CTeamMenuPanel::CTeamMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide,i
 	pSchemes->getBgColor( hTeamWindowText, r, g, b, a );
 	m_pBriefing->setBgColor( r, g, b, a );
 
-	m_pBriefing->setText( gHUD.m_TextMessage.BufferedLocaliseTextString("#Map_Description_not_available") );
+	m_pBriefing->setText( gHUD.m_TextMessage->BufferedLocaliseTextString("#Map_Description_not_available") );
 
 	// Team Menu buttons
 	for (int i = 1; i <= MAX_TEAMS_IN_MENU + 1; i++)
@@ -122,7 +123,7 @@ CTeamMenuPanel::CTeamMenuPanel(int iTrans, int iRemoveMe, int x,int y,int wide,i
 				m_pButtons[i]->setBoundKey( '0' + i );
 			else
 				m_pButtons[i]->setBoundKey( '0' );
-			m_pButtons[i]->setText( gHUD.m_TextMessage.BufferedLocaliseTextString("Auto Assign") );
+			m_pButtons[i]->setText( gHUD.m_TextMessage->BufferedLocaliseTextString("Auto Assign") );
 			m_pButtons[i]->setVisible( true );
 		}
 

--- a/dlls/memory.h
+++ b/dlls/memory.h
@@ -12,27 +12,7 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
-#ifdef _WIN32	//WINDOWS
-
-typedef unsigned __int64 uint64_t;
-typedef unsigned __int32 uint32_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int8 uint8_t;
-typedef __int64 int64_t;
-typedef __int32 int32_t;
-typedef __int16 int16_t;
-typedef __int8 int8_t;
-
-#elif defined(linux)	//LINUX
-
-typedef unsigned int uint32_t;
-typedef unsigned short uint16_t;
-typedef unsigned char uint8_t;
-typedef int int32_t;
-typedef short int16_t;
-typedef char int8_t;
-
-#endif
+#include <stdint.h>
 
 
 typedef struct cl_enginemessages_s

--- a/engine/cdll_int.h
+++ b/engine/cdll_int.h
@@ -29,7 +29,7 @@ extern "C" {
 #include "const.h"
 #include "archtypes.h"
 #include "Sequence.h"
-
+#include "wrect.h"
 
 // this file is included by both the engine and the client-dll,
 // so make sure engine declarations aren't done twice


### PR DESCRIPTION
Valve put all HUD-related headers into hud.h that is included almost everywhere and any slight change to any HUD element class will cause the whole client library to rebuild. That takes quite some time.

I split up hud.h into smaller CHudX.h files, added forward declarations to them in `hud.h` and replaced HUD element variables with smart pointers.

I also renamed cpp files to match the classname and header file name.