### PR TITLE
Fix full update exploit

### DIFF
--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -671,6 +671,8 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 		pPlayer->GiveAmmo( 68, "9mm", _9MM_MAX_CARRY );// 4 full reloads
 	}
 
+	FireTargets("game_playerspawn", pPlayer, pPlayer, USE_TOGGLE, 0);
+
 	pPlayer->m_iAutoWeaponSwitch = aws;
 }
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4111,8 +4111,6 @@ void CBasePlayer :: UpdateClientData( void )
 			}
 		}
 
-		FireTargets( "game_playerspawn", this, this, USE_TOGGLE, 0 );
-
 		// Send flashlight status
 		MESSAGE_BEGIN( MSG_ONE, gmsgFlashlight, NULL, pev );
 			WRITE_BYTE(FlashlightIsOn() ? 1 : 0);


### PR DESCRIPTION
This fixs #9 and also a fullupdate cmd exploit, because there are some maps that uses a game_player_equip entity that targets to "game_playerspawn", so inside of UpdateClientData, game_player_equip is triggered every time you put fullupdate cmd, valve developers didn't see the side effect of putting this here, so I moved it to a better place.