### PR TITLE
Removed hardcoded weapons damage in multiplayer.

### DIFF
--- a/dlls/crossbow.cpp
+++ b/dlls/crossbow.cpp
@@ -183,7 +183,7 @@ void CCrossbowBolt::ExplodeThink( void )
 	int iContents = UTIL_PointContents ( pev->origin );
 	int iScale;
 	
-	pev->dmg = 40;
+	pev->dmg = gSkillData.plrDmgCrossbowNoScope;
 	iScale = 10;
 
 	MESSAGE_BEGIN( MSG_PVS, SVC_TEMPENTITY, pev->origin );
@@ -368,7 +368,7 @@ void CCrossbow::FireSniperBolt()
 	if ( tr.pHit->v.takedamage )
 	{
 		ClearMultiDamage( );
-		CBaseEntity::Instance(tr.pHit)->TraceAttack(m_pPlayer->pev, 120, vecDir, &tr, DMG_BULLET | DMG_NEVERGIB ); 
+		CBaseEntity::Instance(tr.pHit)->TraceAttack(m_pPlayer->pev, gSkillData.plrDmgCrossbowScope, vecDir, &tr, DMG_BULLET | DMG_NEVERGIB ); 
 		ApplyMultiDamage( pev, m_pPlayer->pev );
 	}
 #endif

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -58,22 +58,22 @@ cvar_t  mp_notify_player_status = {"mp_notify_player_status","7"};	// Notificati
 
 cvar_t	mp_welcomecam = { "mp_welcomecam", "1", FCVAR_SERVER };
 
-cvar_t	mp_dmg_crowbar = {"mp_dmg_crowbar" ,"25", FCVAR_SERVER };
-cvar_t	mp_dmg_glock = {"mp_dmg_glock" ,"12", FCVAR_SERVER };
-cvar_t	mp_dmg_357 = {"mp_dmg_357" ,"40", FCVAR_SERVER };
-cvar_t	mp_dmg_mp5 = {"mp_dmg_mp5" ,"12", FCVAR_SERVER };
-cvar_t	mp_dmg_shotgun = {"mp_dmg_shotgun" ,"20", FCVAR_SERVER };
-cvar_t	mp_dmg_xbow_scope = {"mp_dmg_xbow_scope" ,"120", FCVAR_SERVER };
-cvar_t	mp_dmg_xbow_noscope = {"mp_dmg_xbow_noscope" ,"40", FCVAR_SERVER };
-cvar_t	mp_dmg_rpg = {"mp_dmg_rpg" ,"120", FCVAR_SERVER };
-cvar_t	mp_dmg_gauss_primary = {"mp_dmg_gauss_primary" ,"20", FCVAR_SERVER };
-cvar_t	mp_dmg_gauss_secondary = { "mp_dmg_gauss_secondary" ,"200", FCVAR_SERVER };
-cvar_t	mp_dmg_egon = {"mp_dmg_egon" ,"20", FCVAR_SERVER };
-cvar_t	mp_dmg_hornet = {"mp_dmg_hornet" ,"10", FCVAR_SERVER };
-cvar_t	mp_dmg_hgrenade = {"mp_dmg_hgrenade" ,"100", FCVAR_SERVER };
-cvar_t	mp_dmg_satchel = {"mp_dmg_satchel" ,"120", FCVAR_SERVER };
-cvar_t	mp_dmg_tripmine = {"mp_dmg_tripmine" ,"150", FCVAR_SERVER };
-cvar_t	mp_dmg_m203 = {"mp_dmg_m203" ,"100", FCVAR_SERVER };
+cvar_t	mp_dmg_crowbar = { "mp_dmg_crowbar", "25", FCVAR_SERVER };
+cvar_t	mp_dmg_glock = { "mp_dmg_glock", "12", FCVAR_SERVER };
+cvar_t	mp_dmg_357 = { "mp_dmg_357", "40", FCVAR_SERVER };
+cvar_t	mp_dmg_mp5 = { "mp_dmg_mp5", "12", FCVAR_SERVER };
+cvar_t	mp_dmg_shotgun = { "mp_dmg_shotgun", "20", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_scope = { "mp_dmg_xbow_scope", "120", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_noscope = { "mp_dmg_xbow_noscope", "40", FCVAR_SERVER };
+cvar_t	mp_dmg_rpg = { "mp_dmg_rpg", "120", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_primary = { "mp_dmg_gauss_primary", "20", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_secondary = { "mp_dmg_gauss_secondary", "200", FCVAR_SERVER };
+cvar_t	mp_dmg_egon = { "mp_dmg_egon", "20", FCVAR_SERVER };
+cvar_t	mp_dmg_hornet = { "mp_dmg_hornet", "10", FCVAR_SERVER };
+cvar_t	mp_dmg_hgrenade = { "mp_dmg_hgrenade", "100", FCVAR_SERVER };
+cvar_t	mp_dmg_satchel = { "mp_dmg_satchel", "120", FCVAR_SERVER };
+cvar_t	mp_dmg_tripmine = { "mp_dmg_tripmine", "150", FCVAR_SERVER };
+cvar_t	mp_dmg_m203 = { "mp_dmg_m203", "100", FCVAR_SERVER };
 
 // Engine Cvars
 cvar_t 	*g_psv_gravity = NULL;

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -58,22 +58,22 @@ cvar_t  mp_notify_player_status = {"mp_notify_player_status","7"};	// Notificati
 
 cvar_t	mp_welcomecam = { "mp_welcomecam", "1", FCVAR_SERVER };
 
-cvar_t	mp_dmg_crowbar = {"mp_dmg_crowbar","25", FCVAR_SERVER };
-cvar_t	mp_dmg_glock = {"mp_dmg_glock","12", FCVAR_SERVER };
-cvar_t	mp_dmg_357 = {"mp_dmg_357","40", FCVAR_SERVER };
-cvar_t	mp_dmg_mp5 = {"mp_dmg_mp5","12", FCVAR_SERVER };
-cvar_t	mp_dmg_shotgun = {"mp_dmg_shotgun","20", FCVAR_SERVER };
-cvar_t	mp_dmg_xbow_scope = {"mp_dmg_xbow_scope","120", FCVAR_SERVER };
-cvar_t	mp_dmg_xbow_noscope = {"mp_dmg_xbow_noscope","40", FCVAR_SERVER };
-cvar_t	mp_dmg_rpg = {"mp_dmg_rpg","120", FCVAR_SERVER };
-cvar_t	mp_dmg_gauss_primary = {"mp_dmg_gauss_primary","20", FCVAR_SERVER };
-cvar_t	mp_dmg_gauss_secondary = { "mp_dmg_gauss_secondary","200", FCVAR_SERVER };
-cvar_t	mp_dmg_egon = {"mp_dmg_egon","20", FCVAR_SERVER };
-cvar_t	mp_dmg_hornet = {"mp_dmg_hornet","10", FCVAR_SERVER };
-cvar_t	mp_dmg_hgrenade = {"mp_dmg_hgrenade","100", FCVAR_SERVER };
-cvar_t	mp_dmg_satchel = {"mp_dmg_satchel","120", FCVAR_SERVER };
-cvar_t	mp_dmg_tripmine = {"mp_dmg_tripmine","150", FCVAR_SERVER };
-cvar_t	mp_dmg_m203 = {"mp_dmg_m203","100", FCVAR_SERVER };
+cvar_t	mp_dmg_crowbar = {"mp_dmg_crowbar" ,"25", FCVAR_SERVER };
+cvar_t	mp_dmg_glock = {"mp_dmg_glock" ,"12", FCVAR_SERVER };
+cvar_t	mp_dmg_357 = {"mp_dmg_357" ,"40", FCVAR_SERVER };
+cvar_t	mp_dmg_mp5 = {"mp_dmg_mp5" ,"12", FCVAR_SERVER };
+cvar_t	mp_dmg_shotgun = {"mp_dmg_shotgun" ,"20", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_scope = {"mp_dmg_xbow_scope" ,"120", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_noscope = {"mp_dmg_xbow_noscope" ,"40", FCVAR_SERVER };
+cvar_t	mp_dmg_rpg = {"mp_dmg_rpg" ,"120", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_primary = {"mp_dmg_gauss_primary" ,"20", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_secondary = { "mp_dmg_gauss_secondary" ,"200", FCVAR_SERVER };
+cvar_t	mp_dmg_egon = {"mp_dmg_egon" ,"20", FCVAR_SERVER };
+cvar_t	mp_dmg_hornet = {"mp_dmg_hornet" ,"10", FCVAR_SERVER };
+cvar_t	mp_dmg_hgrenade = {"mp_dmg_hgrenade" ,"100", FCVAR_SERVER };
+cvar_t	mp_dmg_satchel = {"mp_dmg_satchel" ,"120", FCVAR_SERVER };
+cvar_t	mp_dmg_tripmine = {"mp_dmg_tripmine" ,"150", FCVAR_SERVER };
+cvar_t	mp_dmg_m203 = {"mp_dmg_m203" ,"100", FCVAR_SERVER };
 
 // Engine Cvars
 cvar_t 	*g_psv_gravity = NULL;

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -58,6 +58,23 @@ cvar_t  mp_notify_player_status = {"mp_notify_player_status","7"};	// Notificati
 
 cvar_t	mp_welcomecam = { "mp_welcomecam", "1", FCVAR_SERVER };
 
+cvar_t	mp_dmg_crowbar = {"mp_dmg_crowbar","25", FCVAR_SERVER };
+cvar_t	mp_dmg_glock = {"mp_dmg_glock","12", FCVAR_SERVER };
+cvar_t	mp_dmg_357 = {"mp_dmg_357","40", FCVAR_SERVER };
+cvar_t	mp_dmg_mp5 = {"mp_dmg_mp5","12", FCVAR_SERVER };
+cvar_t	mp_dmg_shotgun = {"mp_dmg_shotgun","20", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_scope = {"mp_dmg_xbow_scope","120", FCVAR_SERVER };
+cvar_t	mp_dmg_xbow_noscope = {"mp_dmg_xbow_noscope","40", FCVAR_SERVER };
+cvar_t	mp_dmg_rpg = {"mp_dmg_rpg","120", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_primary = {"mp_dmg_gauss_primary","20", FCVAR_SERVER };
+cvar_t	mp_dmg_gauss_secondary = { "mp_dmg_gauss_secondary","200", FCVAR_SERVER };
+cvar_t	mp_dmg_egon = {"mp_dmg_egon","20", FCVAR_SERVER };
+cvar_t	mp_dmg_hornet = {"mp_dmg_hornet","10", FCVAR_SERVER };
+cvar_t	mp_dmg_hgrenade = {"mp_dmg_hgrenade","100", FCVAR_SERVER };
+cvar_t	mp_dmg_satchel = {"mp_dmg_satchel","120", FCVAR_SERVER };
+cvar_t	mp_dmg_tripmine = {"mp_dmg_tripmine","150", FCVAR_SERVER };
+cvar_t	mp_dmg_m203 = {"mp_dmg_m203","100", FCVAR_SERVER };
+
 // Engine Cvars
 cvar_t 	*g_psv_gravity = NULL;
 cvar_t	*g_psv_aim = NULL;
@@ -513,6 +530,23 @@ void GameDLLInit( void )
 	CVAR_REGISTER (&mp_notify_player_status);
 
 	CVAR_REGISTER (&mp_welcomecam);
+
+	CVAR_REGISTER(&mp_dmg_crowbar);
+	CVAR_REGISTER(&mp_dmg_glock);
+	CVAR_REGISTER(&mp_dmg_357);
+	CVAR_REGISTER(&mp_dmg_mp5);
+	CVAR_REGISTER(&mp_dmg_shotgun);
+	CVAR_REGISTER(&mp_dmg_xbow_scope);
+	CVAR_REGISTER(&mp_dmg_xbow_noscope);
+	CVAR_REGISTER(&mp_dmg_rpg);
+	CVAR_REGISTER(&mp_dmg_gauss_primary);
+	CVAR_REGISTER(&mp_dmg_gauss_secondary);
+	CVAR_REGISTER(&mp_dmg_egon);
+	CVAR_REGISTER(&mp_dmg_hornet);
+	CVAR_REGISTER(&mp_dmg_hgrenade);
+	CVAR_REGISTER(&mp_dmg_satchel);
+	CVAR_REGISTER(&mp_dmg_tripmine);
+	CVAR_REGISTER(&mp_dmg_m203);
 
 	// REGISTER CVARS FOR SKILL LEVEL STUFF
 

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -45,6 +45,23 @@ extern cvar_t	allowmonsters;
 extern cvar_t	mp_notify_player_status;
 extern cvar_t	mp_welcomecam;
 
+extern cvar_t	mp_dmg_crowbar;
+extern cvar_t	mp_dmg_glock;
+extern cvar_t	mp_dmg_357;
+extern cvar_t	mp_dmg_mp5;
+extern cvar_t	mp_dmg_shotgun;
+extern cvar_t	mp_dmg_xbow_scope;
+extern cvar_t	mp_dmg_xbow_noscope;
+extern cvar_t	mp_dmg_rpg;
+extern cvar_t	mp_dmg_gauss_primary;
+extern cvar_t	mp_dmg_gauss_secondary;
+extern cvar_t	mp_dmg_egon;
+extern cvar_t	mp_dmg_hornet;
+extern cvar_t	mp_dmg_hgrenade;
+extern cvar_t	mp_dmg_satchel;
+extern cvar_t	mp_dmg_tripmine;
+extern cvar_t	mp_dmg_m203;
+
 // Engine Cvars
 extern cvar_t	*g_psv_gravity;
 extern cvar_t	*g_psv_aim;

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -251,6 +251,7 @@ void CGameRules::RefreshSkillData ( void )
 
 	// Gauss gun
 	gSkillData.plrDmgGauss = GetSkillCvar( "sk_plr_gauss");
+	gSkillData.plrDmgGaussSecondary = 200;
 
 	// Egon Gun
 	gSkillData.plrDmgEgonNarrow = GetSkillCvar( "sk_plr_egon_narrow");

--- a/dlls/gauss.cpp
+++ b/dlls/gauss.cpp
@@ -314,11 +314,11 @@ void CGauss::StartFire( void )
 	
 	if ( gpGlobals->time - m_pPlayer->m_flStartCharge > GetFullChargeTime() )
 	{
-		flDamage = 200;
+		flDamage = gSkillData.plrDmgGaussSecondary;
 	}
 	else
 	{
-		flDamage = 200 * (( gpGlobals->time - m_pPlayer->m_flStartCharge) / GetFullChargeTime() );
+		flDamage = gSkillData.plrDmgGaussSecondary * (( gpGlobals->time - m_pPlayer->m_flStartCharge) / GetFullChargeTime() );
 	}
 
 	if ( m_fPrimaryFire )

--- a/dlls/ggrenade.cpp
+++ b/dlls/ggrenade.cpp
@@ -417,7 +417,7 @@ CGrenade * CGrenade:: ShootTimed( entvars_t *pevOwner, Vector vecStart, Vector v
 	pGrenade->pev->friction = 0.8;
 
 	SET_MODEL(ENT(pGrenade->pev), "models/w_grenade.mdl");
-	pGrenade->pev->dmg = 100;
+	pGrenade->pev->dmg = gSkillData.plrDmgHandGrenade;
 
 	return pGrenade;
 }

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -144,44 +144,48 @@ void CHalfLifeMultiplay::RefreshSkillData( void )
 	gSkillData.suitchargerCapacity = 30;
 
 	// Crowbar whack
-	gSkillData.plrDmgCrowbar = 25;
+	gSkillData.plrDmgCrowbar = mp_dmg_crowbar.value;
 
 	// Glock Round
-	gSkillData.plrDmg9MM = 12;
+	gSkillData.plrDmg9MM = mp_dmg_glock.value;
 
 	// 357 Round
-	gSkillData.plrDmg357 = 40;
+	gSkillData.plrDmg357 = mp_dmg_357.value;
 
 	// MP5 Round
-	gSkillData.plrDmgMP5 = 12;
+	gSkillData.plrDmgMP5 = mp_dmg_mp5.value;
 
 	// M203 grenade
-	gSkillData.plrDmgM203Grenade = 100;
+	gSkillData.plrDmgM203Grenade = mp_dmg_m203.value;
 
 	// Shotgun buckshot
-	gSkillData.plrDmgBuckshot = 20;// fewer pellets in deathmatch
+	gSkillData.plrDmgBuckshot = mp_dmg_shotgun.value;
 
 	// Crossbow
-	gSkillData.plrDmgCrossbowClient = 20;
+	gSkillData.plrDmgCrossbowScope = mp_dmg_xbow_scope.value;
+	gSkillData.plrDmgCrossbowNoScope = mp_dmg_xbow_noscope.value;
 
 	// RPG
-	gSkillData.plrDmgRPG = 120;
+	gSkillData.plrDmgRPG = mp_dmg_rpg.value;
 
 	// Egon
-	gSkillData.plrDmgEgonWide = 20;
-	gSkillData.plrDmgEgonNarrow = 10;
+	gSkillData.plrDmgEgonWide = mp_dmg_egon.value;
 
-	// Hand Grendade
-	gSkillData.plrDmgHandGrenade = 100;
+	// Hand Grenade
+	gSkillData.plrDmgHandGrenade = mp_dmg_hgrenade.value;
 
 	// Satchel Charge
-	gSkillData.plrDmgSatchel = 120;
+	gSkillData.plrDmgSatchel = mp_dmg_satchel.value;
 
 	// Tripmine
-	gSkillData.plrDmgTripmine = 150;
+	gSkillData.plrDmgTripmine = mp_dmg_tripmine.value;
 
 	// hornet
-	gSkillData.plrDmgHornet = 10;
+	gSkillData.plrDmgHornet = mp_dmg_hornet.value;
+
+	// gauss
+	gSkillData.plrDmgGauss = mp_dmg_gauss_primary.value;
+	gSkillData.plrDmgGaussSecondary = mp_dmg_gauss_secondary.value;
 }
 
 // longest the intermission can last, in seconds

--- a/dlls/skill.h
+++ b/dlls/skill.h
@@ -108,10 +108,9 @@ struct skilldata_t
 	float plrDmgHandGrenade;
 	float plrDmgSatchel;
 	float plrDmgTripmine;
-// NEW: added some missing weapons dmg cvars (xbow cvars are only used in multiplayer)
 	float plrDmgGaussSecondary;
-	float plrDmgCrossbowScope;		// normal bolt
-	float plrDmgCrossbowNoScope;	// explosive bolt
+	float plrDmgCrossbowScope;	// normal bolt (used only in multiplayer)
+	float plrDmgCrossbowNoScope;	// explosive bolt (used only in multiplayer)
 
 // weapons shared by monsters
 	float monDmg9MM;

--- a/dlls/skill.h
+++ b/dlls/skill.h
@@ -108,7 +108,11 @@ struct skilldata_t
 	float plrDmgHandGrenade;
 	float plrDmgSatchel;
 	float plrDmgTripmine;
-	
+// NEW: added some missing weapons dmg cvars (xbow cvars are only used in multiplayer)
+	float plrDmgGaussSecondary;
+	float plrDmgCrossbowScope;		// normal bolt
+	float plrDmgCrossbowNoScope;	// explosive bolt
+
 // weapons shared by monsters
 	float monDmg9MM;
 	float monDmgMP5;


### PR DESCRIPTION
- Added mp_dmg_* cvars to avoid hardcoded weapons damage in multiplayer.
- Added some missing weapons damage cvars for gauss (secondary attack) and crossbow (using and not using scope).
- Fixed damage not being set properly on hand grenade.