### PR TITLE
Add colors for ammo hud

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -948,7 +948,6 @@ int CHudAmmo::Draw(float flTime)
 			x += iBarWidth + AmmoWidth/2;;
 
 			// GL Seems to need this
-			ScaleColors(r, g, b, a );
 			x = gHUD.DrawHudNumber(x, y, iFlags | DHN_3DIGITS, gWR.CountAmmo(pw->iAmmoType), r, g, b);		
 
 

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -506,6 +506,8 @@ int CHudAmmo::MsgFunc_AmmoX(const char *pszName, int iSize, void *pbuf)
 
 	gWR.SetAmmo( iIndex, abs(iCount) );
 
+	m_fFade = FADE_TIME;
+
 	return 1;
 }
 

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -891,6 +891,8 @@ int CHudAmmo::Draw(float flTime)
 	else
 		a = MIN_ALPHA;
 
+	float alphaDim = a;
+
 	a *= gHUD.GetHudTransparency();
 	gHUD.GetHudColor(0, 0, r, g, b);
 	ScaleColors(r, g, b, a );
@@ -920,8 +922,11 @@ int CHudAmmo::Draw(float flTime)
 		
 		if (pw->iClip >= 0)
 		{
+			a = alphaDim * gHUD.GetHudTransparency();
+			gHUD.GetHudAmmoColor(pw->iClip, GetMaxClip(pw->szName), r, g, b);
+			ScaleColors(r, g, b, a);
+
 			// room for the number and the '|' and the current ammo
-			
 			x = ScreenWidth - (8 * AmmoWidth) - iIconWidth;
 			x = gHUD.DrawHudNumber(x, y, iFlags | DHN_3DIGITS, pw->iClip, r, g, b);
 
@@ -934,8 +939,6 @@ int CHudAmmo::Draw(float flTime)
 			int iBarWidth =  AmmoWidth/10;
 
 			x += AmmoWidth/2;
-
-			gHUD.GetHudColor(0, 0, r, g, b);
 
 			// draw the | bar
 			FillRGBA(x, y, iBarWidth, gHUD.m_iFontHeight, r, g, b, a);
@@ -950,6 +953,10 @@ int CHudAmmo::Draw(float flTime)
 		}
 		else
 		{
+			a = alphaDim * gHUD.GetHudTransparency();
+			gHUD.GetHudAmmoColor(gWR.CountAmmo(pw->iAmmoType), pw->iMax1, r, g, b);
+			ScaleColors(r, g, b, a);
+
 			// SPR_Draw a bullets only line
 			x = ScreenWidth - 4 * AmmoWidth - iIconWidth;
 			x = gHUD.DrawHudNumber(x, y, iFlags | DHN_3DIGITS, gWR.CountAmmo(pw->iAmmoType), r, g, b);
@@ -969,6 +976,10 @@ int CHudAmmo::Draw(float flTime)
 		// Do we have secondary ammo?
 		if ((pw->iAmmo2Type != 0) && (gWR.CountAmmo(pw->iAmmo2Type) > 0))
 		{
+			a = alphaDim * gHUD.GetHudTransparency();
+			gHUD.GetHudAmmoColor(pw->iClip, GetMaxClip(pw->szName), r, g, b);
+			ScaleColors(r, g, b, a);
+
 			y -= gHUD.m_iFontHeight + gHUD.m_iFontHeight/4;
 			x = ScreenWidth - 4 * AmmoWidth - iIconWidth;
 			x = gHUD.DrawHudNumber(x, y, iFlags|DHN_3DIGITS, gWR.CountAmmo(pw->iAmmo2Type), r, g, b);
@@ -1220,6 +1231,38 @@ int CHudAmmo::DrawWList(float flTime)
 
 }
 
+// m_iMaxClip is never sended to the client, until i figure out another way, this is the best thing we can use
+int CHudAmmo::GetMaxClip(char *weaponname)
+{
+	if (!strcmp(weaponname, "weapon_9mmhandgun"))
+	{
+		return 17;
+	}
+	else if (!strcmp(weaponname, "weapon_9mmAR"))
+	{
+		return 50;
+	}
+	else if (!strcmp(weaponname, "weapon_shotgun"))
+	{
+		return 8;
+	}
+	else if (!strcmp(weaponname, "weapon_crossbow"))
+	{
+		return 5;
+	}
+	else if (!strcmp(weaponname, "weapon_rpg"))
+	{
+		return 1;
+	}
+	else if (!strcmp(weaponname, "weapon_357"))
+	{
+		return 6;
+	}
+	else // if you are using custom weapons, then custom colors for ammo hud aren't going to be used..
+	{
+		return -1;
+	}
+}
 
 /* =================================
 	GetSpriteFromList

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -864,6 +864,37 @@ void CHud::GetHudColor( int hudPart, int value, int &r, int &g, int &b )
 	b = c->b;
 }
 
+void CHud::GetHudAmmoColor(int value, int maxvalue, int &r, int &g, int &b)
+{
+	RGBA *c;
+	if (maxvalue == -1) // if you are using custom weapons, then default colors are going to be used....
+	{
+		ParseColor(m_pCvarColor->string, m_hudColor); c = &m_hudColor;
+	}
+	else if ((value * 100) / maxvalue > 90)
+	{
+		ParseColor(m_pCvarColor1->string, m_hudColor1); c = &m_hudColor1;
+	}
+	else if ((value * 100) / maxvalue > 50)
+	{
+		ParseColor(m_pCvarColor2->string, m_hudColor2); c = &m_hudColor2;
+	}
+	else if ((value * 100) / maxvalue > 20)
+	{
+		ParseColor(m_pCvarColor3->string, m_hudColor3); c = &m_hudColor3;
+	}
+	else
+	{
+		r = 255;
+		g = 0;
+		b = 0;
+		return; 
+	}
+	r = c->r;
+	g = c->g;
+	b = c->b;
+}
+
 float CHud::GetHudTransparency()
 {
 	float hud_draw = m_pCvarDraw->value;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -124,6 +124,7 @@ public:
 	int MsgFunc_ItemPickup( const char *pszName, int iSize, void *pbuf );
 	int MsgFunc_HideWeapon( const char *pszName, int iSize, void *pbuf );
 
+	int GetMaxClip(char* weaponname);
 	int GetMaxSlot(void) { return m_iMaxSlot; }
 	void SlotInput( int iSlot );
 	void _cdecl UserCmd_Slot1( void );
@@ -744,7 +745,8 @@ public:
 	int GetNumWidth(int iNumber, int iFlags);
 	int GetHudCharWidth(int c);
 	int CalculateCharWidth(int c);
-	void GetHudColor( int hudPart, int value, int &r, int &g, int &b );
+	void GetHudColor(int hudPart, int value, int &r, int &g, int &b);
+	void GetHudAmmoColor(int value, int maxvalue, int &r, int &g, int &b);
 	float GetHudTransparency();
 
 private:


### PR DESCRIPTION
## Info
It will color ammo depending on how much you have.
- 0..20% ammo - red;
- 21..50% ammo - orange;
- 51..90% ammo - yellow;
- 91..100% ammo - green.
## Fixed
- Fixed backpack ammo not flashing when it changes
- Fixed inconsistent dimming in backpack ammo
## Screens
![Red ammo](https://imgur.com/snis1E9.png)
![Orange ammo](https://imgur.com/fPkFx6s.png)
![Yellow ammo](https://imgur.com/f1zkDPk.png)
![Green ammo](https://imgur.com/GS5LzEd.png)
