### PR TITLE
Add hud speedometer

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -427,6 +427,7 @@ void CHud :: Init( void )
 	m_Flash.Init();
 	m_Message.Init();
 	m_StatusBar.Init();
+	m_Speedometer.Init();
 	m_DeathNotice.Init();
 	m_AmmoSecondary.Init();
 	m_TextMessage.Init();
@@ -584,6 +585,7 @@ void CHud :: VidInit( void )
 	m_Flash.VidInit();
 	m_Message.VidInit();
 	m_StatusBar.VidInit();
+	m_Speedometer.VidInit();
 	m_DeathNotice.VidInit();
 	m_SayText.VidInit();
 	m_Menu.VidInit();

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -740,7 +740,8 @@ public:
 
 	int m_iFontHeight;
 	int DrawHudNumber(int x, int y, int iFlags, int iNumber, int r, int g, int b );
-	int DrawHudNumberCentered(int x, int y, int flags, int number, int r, int g, int b);
+	int DrawHudNumber(int x, int y, int number, int r, int g, int b);
+	int DrawHudNumberCentered(int x, int y, int number, int r, int g, int b);
 	int DrawHudString(int x, int y, const char *szString, int r, int g, int b );
 	int DrawHudStringReverse( int xpos, int ypos, const char *szString, int r, int g, int b );
 	int DrawHudNumberString( int xpos, int ypos, int iNumber, int r, int g, int b );

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -677,6 +677,8 @@ struct CharWidths
 	}
 };
 
+#include "hud_speedometer.h"
+
 #include "aghudglobal.h"
 #include "aghudcountdown.h"
 #include "aghudctf.h"
@@ -738,6 +740,7 @@ public:
 
 	int m_iFontHeight;
 	int DrawHudNumber(int x, int y, int iFlags, int iNumber, int r, int g, int b );
+	int DrawHudNumberCentered(int x, int y, int flags, int number, int r, int g, int b);
 	int DrawHudString(int x, int y, const char *szString, int r, int g, int b );
 	int DrawHudStringReverse( int xpos, int ypos, const char *szString, int r, int g, int b );
 	int DrawHudNumberString( int xpos, int ypos, int iNumber, int r, int g, int b );
@@ -776,6 +779,7 @@ public:
 	CHudFlashlight		m_Flash;
 	CHudMessage			m_Message;
 	CHudStatusBar		m_StatusBar;
+	CHudSpeedometer		m_Speedometer;
 	CHudDeathNotice		m_DeathNotice;
 	CHudSayText			m_SayText;
 	CHudMenu			m_Menu;

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -326,12 +326,44 @@ int CHud :: DrawHudNumber( int x, int y, int iFlags, int iNumber, int r, int g, 
 	return x;
 }
 
-int CHud::DrawHudNumberCentered(int x, int y, int flags, int number, int r, int g, int b)
+static constexpr int ten_powers[] = {
+	1,
+	10,
+	100,
+	1000,
+	10000,
+	100000,
+	1000000,
+	10000000,
+	100000000,
+	1000000000
+};
+
+int CHud::DrawHudNumber(int x, int y, int number, int r, int g, int b)
 {
 	auto digit_width = GetSpriteRect(m_HUD_number_0).right - GetSpriteRect(m_HUD_number_0).left;
 	auto digit_count = number > 9 ? (int)log10((double)number) + 1 : 1;
 
-	return DrawHudNumber(x - (digit_width * digit_count) / 2, y, flags, number, r, g, b);
+	for (int i = digit_count; i > 0; --i)
+	{
+		int digit = number / ten_powers[i - 1];
+
+		SPR_Set(GetSprite(m_HUD_number_0 + digit), r, g, b);
+		SPR_DrawAdditive(0, x, y, &GetSpriteRect(m_HUD_number_0 + digit));
+		x += digit_width;
+
+		number -= digit * ten_powers[i - 1];
+	}
+
+	return x;
+}
+
+int CHud::DrawHudNumberCentered(int x, int y, int number, int r, int g, int b)
+{
+	auto digit_width = GetSpriteRect(m_HUD_number_0).right - GetSpriteRect(m_HUD_number_0).left;
+	auto digit_count = number > 9 ? (int)log10((double)number) + 1 : 1;
+
+	return DrawHudNumber(x - (digit_width * digit_count) / 2, y, number, r, g, b);
 }
 
 int CHud::GetNumWidth( int iNumber, int iFlags )

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -326,6 +326,13 @@ int CHud :: DrawHudNumber( int x, int y, int iFlags, int iNumber, int r, int g, 
 	return x;
 }
 
+int CHud::DrawHudNumberCentered(int x, int y, int flags, int number, int r, int g, int b)
+{
+	auto digit_width = GetSpriteRect(m_HUD_number_0).right - GetSpriteRect(m_HUD_number_0).left;
+	auto digit_count = number > 9 ? (int)log10((double)number) + 1 : 1;
+
+	return DrawHudNumber(x - (digit_width * digit_count) / 2, y, flags, number, r, g, b);
+}
 
 int CHud::GetNumWidth( int iNumber, int iFlags )
 {

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -23,6 +23,9 @@ int CHudSpeedometer::VidInit()
 
 int CHudSpeedometer::Draw(float time)
 {
+	if ((gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH) || gEngfuncs.IsSpectateOnly())
+		return 0;
+
 	if (hud_speedometer->value == 0.0f)
 		return 0;
 

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -28,7 +28,7 @@ int CHudSpeedometer::Draw(float time)
 
 	int r, g, b;
 	gHUD.GetHudColor(0, 0, r, g, b);
-	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, DHN_DRAWZERO, speed, r, g, b);
+	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, speed, r, g, b);
 
 	return 0;
 }

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -28,9 +28,30 @@ int CHudSpeedometer::Draw(float time)
 	if (m_pCvarSpeedometer->value == 0.0f)
 		return 0;
 
+	if (m_iOldSpeed != m_iSpeed)
+		m_fFade = FADE_TIME;
+
 	int r, g, b;
+	float a;
+
+	if (gHUD.m_pCvarDim->value == 0)
+		a = MIN_ALPHA + ALPHA_AMMO_MAX;
+	else if (m_fFade > 0)
+	{
+		// Fade the health number back to dim
+		m_fFade -= (gHUD.m_flTimeDelta * 20);
+		if (m_fFade <= 0)
+			m_fFade = 0;
+		a = MIN_ALPHA + (m_fFade / FADE_TIME) * ALPHA_AMMO_FLASH;
+	} else
+		a = MIN_ALPHA;
+
+	a *= gHUD.GetHudTransparency();
 	gHUD.GetHudColor(0, 0, r, g, b);
+	ScaleColors(r, g, b, a);
 	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, m_iSpeed, r, g, b);
+
+	m_iOldSpeed = m_iSpeed;
 
 	return 0;
 }

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -1,15 +1,14 @@
-#include <cmath>
-#include <cstring>
-
 #include "hud.h"
 #include "cl_util.h"
 #include "parsemsg.h"
+
+#include <cmath>
 
 int CHudSpeedometer::Init(void)
 {
 	m_iFlags = HUD_ACTIVE;
 	
-	hud_speedometer = CVAR_CREATE("hud_speedometer", "0", FCVAR_ARCHIVE);
+	m_pCvarSpeedometer = CVAR_CREATE("hud_speedometer", "0", FCVAR_ARCHIVE);
 
 	gHUD.AddHudElem(this);
 
@@ -26,17 +25,17 @@ int CHudSpeedometer::Draw(float time)
 	if ((gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH) || gEngfuncs.IsSpectateOnly())
 		return 0;
 
-	if (hud_speedometer->value == 0.0f)
+	if (m_pCvarSpeedometer->value == 0.0f)
 		return 0;
 
 	int r, g, b;
 	gHUD.GetHudColor(0, 0, r, g, b);
-	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, speed, r, g, b);
+	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, m_iSpeed, r, g, b);
 
 	return 0;
 }
 
 void CHudSpeedometer::UpdateSpeed(const float velocity[2])
 {
-	speed = std::round(std::hypot(velocity[0], velocity[1]));
+	m_iSpeed = std::round(std::hypot(velocity[0], velocity[1]));
 }

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -1,0 +1,39 @@
+#include <cmath>
+#include <cstring>
+
+#include "hud.h"
+#include "cl_util.h"
+#include "parsemsg.h"
+
+int CHudSpeedometer::Init(void)
+{
+	m_iFlags = HUD_ACTIVE;
+	
+	hud_speedometer = CVAR_CREATE("hud_speedometer", "0", FCVAR_ARCHIVE);
+
+	gHUD.AddHudElem(this);
+
+	return 0;
+}
+
+int CHudSpeedometer::VidInit()
+{
+	return 1;
+}
+
+int CHudSpeedometer::Draw(float time)
+{
+	if (hud_speedometer->value == 0.0f)
+		return 0;
+
+	int r, g, b;
+	gHUD.GetHudColor(0, 0, r, g, b);
+	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, DHN_DRAWZERO, speed, r, g, b);
+
+	return 0;
+}
+
+void CHudSpeedometer::UpdateSpeed(const float velocity[2])
+{
+	speed = std::round(std::hypot(velocity[0], velocity[1]));
+}

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -22,7 +22,7 @@ int CHudSpeedometer::VidInit()
 
 int CHudSpeedometer::Draw(float time)
 {
-	if ((gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH) || gEngfuncs.IsSpectateOnly())
+	if ((gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH) || g_IsSpectator[gEngfuncs.GetLocalPlayer()->index])
 		return 0;
 
 	if (m_pCvarSpeedometer->value == 0.0f)

--- a/cl_dll/hud_speedometer.h
+++ b/cl_dll/hud_speedometer.h
@@ -10,7 +10,9 @@ public:
 	void UpdateSpeed(const float velocity[2]);
 
 private:
+	int m_iOldSpeed;
 	int m_iSpeed;
+	float m_fFade;
 	cvar_t *m_pCvarSpeedometer;
 };
 

--- a/cl_dll/hud_speedometer.h
+++ b/cl_dll/hud_speedometer.h
@@ -3,17 +3,15 @@
 
 class CHudSpeedometer : public CHudBase
 {
-	int speed;
-
-	cvar_t *hud_speedometer;
-
 public:
 	virtual int Init();
 	virtual int VidInit();
 	virtual int Draw(float time);
-
 	void UpdateSpeed(const float velocity[2]);
 
+private:
+	int m_iSpeed;
+	cvar_t *m_pCvarSpeedometer;
 };
 
 #endif // __HUD_SPEEDOMETER_H__

--- a/cl_dll/hud_speedometer.h
+++ b/cl_dll/hud_speedometer.h
@@ -1,0 +1,19 @@
+#ifndef __HUD_SPEEDOMETER_H__
+#define __HUD_SPEEDOMETER_H__
+
+class CHudSpeedometer : public CHudBase
+{
+	int speed;
+
+	cvar_t *hud_speedometer;
+
+public:
+	virtual int Init();
+	virtual int VidInit();
+	virtual int Draw(float time);
+
+	void UpdateSpeed(const float velocity[2]);
+
+};
+
+#endif // __HUD_SPEEDOMETER_H__

--- a/cl_dll/msvc/client.vcxproj
+++ b/cl_dll/msvc/client.vcxproj
@@ -206,6 +206,7 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClCompile Include="..\hud_scores.cpp" />
     <ClCompile Include="..\hud_servers.cpp" />
     <ClCompile Include="..\hud_spectator.cpp" />
+    <ClCompile Include="..\hud_speedometer.cpp" />
     <ClCompile Include="..\hud_timer.cpp" />
     <ClCompile Include="..\hud_update.cpp" />
     <ClCompile Include="..\input.cpp" />
@@ -293,6 +294,7 @@ CALL "$(ProjectDir)PreBuild.bat" "$(ProjectDir)..\" "$(ProjectDir)..\..\"
     <ClInclude Include="..\hud_servers.h" />
     <ClInclude Include="..\hud_servers_priv.h" />
     <ClInclude Include="..\hud_spectator.h" />
+    <ClInclude Include="..\hud_speedometer.h" />
     <ClInclude Include="..\in_defs.h" />
     <ClInclude Include="..\jpeg\jpge.h" />
     <ClInclude Include="..\kbutton.h" />

--- a/cl_dll/msvc/client.vcxproj.filters
+++ b/cl_dll/msvc/client.vcxproj.filters
@@ -349,6 +349,9 @@
     <ClCompile Include="..\hud_scores.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\hud_speedometer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ammo.h">
@@ -547,6 +550,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\aghudlocation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hud_speedometer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1608,6 +1608,8 @@ void V_CalcSpectatorRefdef ( struct ref_params_s * pparams )
 
 void DLLEXPORT V_CalcRefdef( struct ref_params_s *pparams )
 {
+	gHUD.m_Speedometer.UpdateSpeed(pparams->simvel);
+
 	// intermission / finale rendering
 	if ( pparams->intermission )
 	{	


### PR DESCRIPTION
Useful when you are trying to improve your bhop skills. Thanks to Yalter, part of this code is from his OpenAG client.
By default is off, to turn it on, type `hud_speedometer` 1 in console.
How it looks in game:
![Screenshot Speedometer](https://imgur.com/QVcoaJU.png)