### PR TITLE
 Server: Send bots to welcome cam and not allow players to leave it too soon

### DIFF
--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -653,7 +653,7 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 	{
 		// don't let him spawn as soon as he enters the server
 		// give enough time to plugins to send the player to spectator mode
-		pPlayer->m_flNextAttack = 1.0;
+		pPlayer->m_flNextAttack = 0.2;
 
 		pPlayer->StartWelcomeCam();
 		return;

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -649,8 +649,12 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 	CBaseEntity	*pWeaponEntity = NULL;
 
 	// Start welcome cam for new players
-	if (!pPlayer->m_bPutInServer && !pPlayer->m_bIsBot && mp_welcomecam.value != 0)
+	if (!pPlayer->m_bPutInServer && mp_welcomecam.value != 0)
 	{
+		// don't let him spawn as soon as he enters the server
+		// give enough time to plugins to send the player to spectator mode
+		pPlayer->m_flNextAttack = 1.0;
+
 		pPlayer->StartWelcomeCam();
 		return;
 	}

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1942,7 +1942,14 @@ void CBasePlayer::PreThink(void)
 	// Welcome cam buttons handling
 	if (m_bInWelcomeCam)
 	{
-		if (m_afButtonPressed & IN_ATTACK)
+		if (m_flNextAttack > 0)
+			return;
+
+		if (m_bIsBot) 
+		{
+			StopWelcomeCam();
+		} 
+		else if (m_afButtonPressed & IN_ATTACK )
 		{
 			StopWelcomeCam();
 		}

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -332,7 +332,7 @@ public:
 	BOOL m_bPutInServer;	// we set it after PutInServer finished
 	BOOL m_bIsBot;			// we set it at PutInServer start
 	BOOL IsConnected() { return m_bConnected; }
-	void Disconnect() { m_bConnected = FALSE; m_bPutInServer = FALSE; m_bIsBot = FALSE; }
+	void Disconnect() { m_bConnected = FALSE; m_bPutInServer = FALSE; m_bIsBot = FALSE; m_bInWelcomeCam = FALSE; }
 
 	Vector m_vecLastViewAngles;
 


### PR DESCRIPTION
Sending connecting players to spectator mode using a task works fine, but with bots this is not the case.

This fix blocks bots spawn by sending them to welcome cam mode and letting them spawn after one second.

Basically, to send a player to spectator mode when he is connecting, you have to do it this way to avoid some scoreboard glitchs, like missing server name, entering players not having a team assigned, etc. ([Check it here](http://aghl.ru/forum/viewtopic.php?f=12&t=2620&start=30#p30676)).
- Use a task to send to spectator the player with a delay of 0.1 seconds in client_putinserver() (you need to have `mp_welcomecam` turned on)

PD: Maybe this pull request requires a title change and a better explanation.