### PR TITLE
Client: Add cvars to hide corpses and to fix standing corpses

### DIFF
--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright Â© 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -64,6 +64,14 @@ int DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *mode
 	default:
 		break;
 	}
+
+	if (gHUD.m_pCvarFixStandingCorpses->value > 0 
+		&& (ent->player || ent->curstate.renderfx == kRenderFxDeadPlayer) && ent->curstate.framerate == 0)
+		ent->curstate.frame = 255;
+
+	if (gHUD.m_pCvarHideCorpses->value > 0 && ent->curstate.renderfx == kRenderFxDeadPlayer)
+		return 0;	
+
 	// each frame every entity passes this function, so the overview hooks it to filter the overview entities
 	// in spectator mode:
 	// each frame every entity passes this function, so the overview hooks 

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -375,6 +375,8 @@ void CHud :: Init( void )
 	CVAR_CREATE( "cl_forceteammatescolors", "", FCVAR_ARCHIVE );
 	m_pCvarBunnyHop = CVAR_CREATE( "cl_bunnyhop", "1", 0 );		// controls client-side bunnyhop enabling
 	CVAR_CREATE( "cl_autowepswitch", "1", FCVAR_ARCHIVE | FCVAR_USERINFO );		// controls autoswitching to best weapon on pickup
+	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
+	m_pCvarFixStandingCorpses = CVAR_CREATE("cl_fix_standing_corpses", "0", FCVAR_ARCHIVE);
 
 	default_fov = CVAR_CREATE( "default_fov", "90", 0 );
 	m_pCvarStealMouse = CVAR_CREATE( "hud_capturemouse", "1", FCVAR_ARCHIVE );

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -735,6 +735,8 @@ public:
 	cvar_t	*m_pCvarShowSteamId;
 	cvar_t	*m_pCvarColorText;
 	cvar_t	*m_pCvarRDynamicEntLight;
+	cvar_t	*m_pCvarHideCorpses;
+	cvar_t	*m_pCvarFixStandingCorpses;
 
 	int m_iFontHeight;
 	int DrawHudNumber(int x, int y, int iFlags, int iNumber, int r, int g, int b );


### PR DESCRIPTION
Cvar "cl_fix_standing_corpses" fix the issue with standing bodies leaved by players with high FPS.

Cvar "cl_hidecorpses" gives you the ability to hide corpses, useful to counter standing bodies leaved by players with high FPS and also if bodies bother you.

I recommend to leave always on the first one, because if you are only using the hiding corpses option, when the player is dead and he didn't respawn, you will be able to see his corpse standing yet, until he respawns.