### PR TITLE
Allow to disable respawn fix and move laggy corpses fix to AddToFullPack()

### DIFF
--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1332,6 +1332,11 @@ int AddToFullPack( struct entity_state_s *state, int e, edict_t *ent, edict_t *h
 		state->health		= ent->v.health;
 	}
 
+	if (ent->v.renderfx == kRenderFxDeadPlayer) {
+		state->movetype = MOVETYPE_NONE;
+		state->solid = SOLID_NOT;
+	}
+
 	return 1;
 }
 

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -57,6 +57,7 @@ cvar_t  mp_chattime = {"mp_chattime","10", FCVAR_SERVER };
 cvar_t  mp_notify_player_status = {"mp_notify_player_status","7"};	// Notifications about join/leave/spectate
 
 cvar_t	mp_welcomecam = { "mp_welcomecam", "1", FCVAR_SERVER };
+cvar_t	mp_respawn_fix = { "mp_respawn_fix", "1", FCVAR_SERVER };
 
 cvar_t	mp_dmg_crowbar = { "mp_dmg_crowbar", "25", FCVAR_SERVER };
 cvar_t	mp_dmg_glock = { "mp_dmg_glock", "12", FCVAR_SERVER };
@@ -530,6 +531,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER (&mp_notify_player_status);
 
 	CVAR_REGISTER (&mp_welcomecam);
+	CVAR_REGISTER (&mp_respawn_fix);
 
 	CVAR_REGISTER(&mp_dmg_crowbar);
 	CVAR_REGISTER(&mp_dmg_glock);

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -44,6 +44,7 @@ extern cvar_t	defaultteam;
 extern cvar_t	allowmonsters;
 extern cvar_t	mp_notify_player_status;
 extern cvar_t	mp_welcomecam;
+extern cvar_t	mp_respawn_fix;
 
 extern cvar_t	mp_dmg_crowbar;
 extern cvar_t	mp_dmg_glock;

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -946,14 +946,13 @@ void CBasePlayer::Killed( entvars_t *pevAttacker, int iGib )
 		WRITE_BYTE(0);
 	MESSAGE_END();
 
-	// Make dead player not solid so it will not lag other players passing over it
-	pev->solid = SOLID_NOT;
 
 	// UNDONE: Put this in, but add FFADE_PERMANENT and make fade time 8.8 instead of 4.12
 	// UTIL_ScreenFade( edict(), Vector(128,0,0), 6, 15, 255, FFADE_OUT | FFADE_MODULATE );
 
 	if ( ( pev->health < -40 && iGib != GIB_NEVER ) || iGib == GIB_ALWAYS )
 	{
+		pev->solid = SOLID_NOT;
 		GibMonster();	// This clears pev->model
 		pev->effects |= EF_NODRAW;
 		return;

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1316,7 +1316,7 @@ void CBasePlayer::PlayerDeathThink(void)
 	if (pev->modelindex && (!m_fSequenceFinished) && (pev->deadflag == DEAD_DYING))
 		StudioFrameAdvance( );
 
-	if (mp_respawn_fix.value > 0)
+	if (mp_respawn_fix.value <= 0)
 	{
 		m_iRespawnFrames++;
 		if (m_iRespawnFrames < 120)
@@ -1328,6 +1328,10 @@ void CBasePlayer::PlayerDeathThink(void)
 		if (gpGlobals->time < m_flDeathAnimationStartTime + 1.5)
 			return;
 	}
+
+	// make sure players with high fps finish the animation
+	if (pev->frame < 255)
+		pev->frame = 255;
 
 	// once we're done animating our death and we're on the ground, we want to set movetype to None so our dead body won't do collisions and stuff anymore
 	// this prevents a bug where the dead body would go to a player's head if he walked over it while the dead player was clicking their button to respawn

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -912,6 +912,7 @@ void CBasePlayer::Killed( entvars_t *pevAttacker, int iGib )
 
 	SetAnimation( PLAYER_DIE );
 	
+	m_iRespawnFrames = 0;
 	m_flDeathAnimationStartTime = gpGlobals->time;
 
 	pev->modelindex = g_ulModelIndexPlayer;    // don't use eyes
@@ -1315,9 +1316,18 @@ void CBasePlayer::PlayerDeathThink(void)
 	if (pev->modelindex && (!m_fSequenceFinished) && (pev->deadflag == DEAD_DYING))
 		StudioFrameAdvance( );
 
-	// time given to animate corpse and don't allow to respawn till this time ends
-	if (gpGlobals->time < m_flDeathAnimationStartTime + 1.5)
-		return;
+	if (mp_respawn_fix.value > 0)
+	{
+		m_iRespawnFrames++;
+		if (m_iRespawnFrames < 120)
+			return;
+	}
+	else
+	{
+		// time given to animate corpse and don't allow to respawn till this time ends
+		if (gpGlobals->time < m_flDeathAnimationStartTime + 1.5)
+			return;
+	}
 
 	// once we're done animating our death and we're on the ground, we want to set movetype to None so our dead body won't do collisions and stuff anymore
 	// this prevents a bug where the dead body would go to a player's head if he walked over it while the dead player was clicking their button to respawn
@@ -1369,6 +1379,7 @@ void CBasePlayer::PlayerDeathThink(void)
 		return;
 
 	pev->button = 0;
+	m_iRespawnFrames = 0;
 	m_flDeathAnimationStartTime = 0;
 
 	//ALERT(at_console, "Respawn\n");

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -184,6 +184,7 @@ public:
 	Vector				m_vecAutoAim;
 	BOOL				m_fOnTarget;
 	int					m_iDeaths;
+	int					m_iRespawnFrames;	// used in PlayerDeathThink() to make sure players can always respawn
 	float				m_flDeathAnimationStartTime;	// used in PlayerDeathThink() to make sure players can always respawn
 
 	int m_lastx, m_lasty;  // These are the previous update's crosshair angles, DON"T SAVE/RESTORE


### PR DESCRIPTION
Most players find this fix annoying because of the delay. I added an option to disable it, and with that, a simple fix for standing corpses.
Also, I moved the fix you did for laggy corpses because it wasn't working properly when the respawn fix is disabled and corpses are from players playing with high FPS. I tested moving it to AddToFullPack() and it's works, just like you did from clientside.