### PR TITLE
Update entity_state.h to fix linux build

### DIFF
--- a/common/entity_state.h
+++ b/common/entity_state.h
@@ -15,10 +15,9 @@
 #if !defined( ENTITY_STATEH )
 #define ENTITY_STATEH
 #ifdef _WIN32
-#ifndef __MINGW32__
 #pragma once
-#endif /* not __MINGW32__ */
 #endif
+#include <inttypes.h>
 
 // For entityType below
 #define ENTITY_NORMAL		(1<<0)
@@ -195,7 +194,7 @@ typedef struct local_state_s
 typedef struct packet_entities_s
 {
 	int num_entities;
-	unsigned __int8 flags[32];
+	uint8_t flags[32];
 	entity_state_t* entities;
 } packet_entities_t;
 
@@ -210,15 +209,15 @@ typedef struct frame_s
 	clientdata_t clientdata;
 	weapon_data_t weapondata[64];
 	packet_entities_t packet_entities;
-	unsigned __int16 clientbytes;
-	unsigned __int16 playerinfobytes;
-	unsigned __int16 packetentitybytes;
-	unsigned __int16 tentitybytes;
-	unsigned __int16 soundbytes;
-	unsigned __int16 eventbytes;
-	unsigned __int16 usrbytes;
-	unsigned __int16 voicebytes;
-	unsigned __int16 msgbytes;
+	uint16_t clientbytes;
+	uint16_t playerinfobytes;
+	uint16_t packetentitybytes;
+	uint16_t tentitybytes;
+	uint16_t soundbytes;
+	uint16_t eventbytes;
+	uint16_t usrbytes;
+	uint16_t voicebytes;
+	uint16_t msgbytes;
 } frame_t;
 
 #endif // !ENTITY_STATEH


### PR DESCRIPTION
This fix an issue when compiling server dll for linux. Thanks to tmp64, this file is taken from his Bugfixed HL fork.

Also it would be nice to add in the build instructions that you require to use at least GCC 3.4.x to compile this, because metamod-p doesn't recognize newers versions (this happens with GCC 5.x).