### PR TITLE
Add CI for automatic building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-
   build-linux:
     runs-on: ubuntu-16.04
 
@@ -70,29 +69,19 @@ jobs:
     steps: 
     - name: Checkout repository
       uses: actions/checkout@v2
-
+        
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-
-    # The batch script isn't working as expected and generates a bad appversion.h
-    # Use an empty appversion.h instead
-    - name: Disable app versioning
-      shell: cmd
+      
+    # Github Actions doesn't fetch tags by default https://github.com/actions/checkout/issues/206
+    # This will fix the auto-versioning script and the build will end correctly
+    - name: Fetch tags
       run: |
-        echo #ifndef __APPVERSION_H__ >> dlls/appversion.h
-        echo #define __APPVERSION_H__ >> dlls/appversion.h
-        echo #define APP_VERSION "0.0.0" >> dlls/appversion.h
-        echo #define APP_VERSION_C 0,0,0,0 >> dlls/appversion.h
-        echo #define APP_VERSION_DATE "?" >> dlls/appversion.h
-        echo #define APP_VERSION_FLAGS VS_FF_SPECIALBUILD >> dlls/appversion.h
-        echo #define APP_VERSION_SPECIALBUILD "modified" >> dlls/appversion.h
-        echo #endif >> dlls/appversion.h
-
-    # Note: I disable too the build events to prevent the app versioning until I find a way to fix it
+        git fetch --prune --unshallow --tags
+        
     - name: Build release
-      shell: cmd
       run: |
-        msbuild multiplayer.sln -target:hl /p:Configuration=Debug /p:PreBuildEventUseInBuild=false /p:PostBuildEventUseInBuild=false 
+        msbuild multiplayer.sln -target:hl
 
         mkdir bugfixedhl-windows
         mkdir bugfixedhl-windows\dlls
@@ -106,4 +95,3 @@ jobs:
       with:
         name: bugfixedhl-windows
         path: bugfixedhl-windows
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,109 @@
+name: C/C++ CI
+
+on:
+  push:
+    #branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build-linux:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    - name: Download dependencies
+      run: |
+        mkdir gcc-3.4
+        cd gcc-3.4
+
+        wget http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.4/cpp-3.4_3.4.6-6ubuntu5_amd64.deb  
+        wget http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.4/gcc-3.4-base_3.4.6-6ubuntu5_amd64.deb
+        wget http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.4/g++-3.4_3.4.6-6ubuntu5_amd64.deb  
+        wget http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.4/libstdc++6-dev_3.4.6-6ubuntu5_amd64.deb
+        wget http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.4/gcc-3.4_3.4.6-6ubuntu5_amd64.deb
+
+        cd $GITHUB_WORKSPACE
+
+    - name: Install dependencies
+      run: |
+        # Install 32 bits libraries
+        sudo apt-get install gcc-multilib g++-multilib
+
+        cd gcc-3.4
+
+        # Note: I had to force the install of libstdc because g++ depends on it and vice versa
+        sudo dpkg -i gcc-3.4-base_3.4.6-6ubuntu5_amd64.deb
+        sudo dpkg -i cpp-3.4_3.4.6-6ubuntu5_amd64.deb
+        sudo dpkg -i gcc-3.4_3.4.6-6ubuntu5_amd64.deb
+        sudo dpkg --force-all -i libstdc++6-dev_3.4.6-6ubuntu5_amd64.deb
+        sudo dpkg -i g++-3.4_3.4.6-6ubuntu5_amd64.deb
+
+        cd $GITHUB_WORKSPACE
+
+    - name: Build release
+      run: |
+        # Note: I set GCC 3.4 as the default compiler because newer versions don't work with some metamod versions
+        cd dlls
+        make CC=gcc-3.4
+        cd $GITHUB_WORKSPACE
+
+        mkdir bugfixedhl-linux
+        mkdir -p bugfixedhl-linux/dlls
+
+        cp -i dlls/hl_i386.so bugfixedhl-linux/dlls/hl.so
+        cp -i network/delta.lst bugfixedhl-linux
+        cp -i Readme.txt bugfixedhl-linux
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: bugfixedhl-linux
+        path: bugfixedhl-linux/
+
+  build-windows:
+    runs-on: windows-2019
+  
+    steps: 
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    # The batch script isn't working as expected and generates a bad appversion.h
+    # Use an empty appversion.h instead
+    - name: Disable app versioning
+      shell: cmd
+      run: |
+        echo #ifndef __APPVERSION_H__ >> dlls/appversion.h
+        echo #define __APPVERSION_H__ >> dlls/appversion.h
+        echo #define APP_VERSION "0.0.0" >> dlls/appversion.h
+        echo #define APP_VERSION_C 0,0,0,0 >> dlls/appversion.h
+        echo #define APP_VERSION_DATE "?" >> dlls/appversion.h
+        echo #define APP_VERSION_FLAGS VS_FF_SPECIALBUILD >> dlls/appversion.h
+        echo #define APP_VERSION_SPECIALBUILD "modified" >> dlls/appversion.h
+        echo #endif >> dlls/appversion.h
+
+    # Note: I disable too the build events to prevent the app versioning until I find a way to fix it
+    - name: Build release
+      shell: cmd
+      run: |
+        msbuild multiplayer.sln -target:hl /p:Configuration=Debug /p:PreBuildEventUseInBuild=false /p:PostBuildEventUseInBuild=false 
+
+        mkdir bugfixedhl-windows
+        mkdir bugfixedhl-windows\dlls
+
+        copy dlls\msvc\Debug\hl.dll bugfixedhl-windows\dlls\
+        copy network\delta.lst bugfixedhl-windows
+        copy Readme.txt bugfixedhl-windows
+      
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: bugfixedhl-windows
+        path: bugfixedhl-windows
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     
     - name: Download dependencies
       run: |
@@ -69,15 +71,11 @@ jobs:
     steps: 
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: 
+        fetch-depth: 0
         
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-      
-    # Github Actions doesn't fetch tags by default https://github.com/actions/checkout/issues/206
-    # This will fix the auto-versioning script and the build will end correctly
-    - name: Fetch tags
-      run: |
-        git fetch --prune --unshallow --tags
         
     - name: Build release
       run: |


### PR DESCRIPTION
Hello there, what this pull request basically does is building BugfixedHL server-side part for Windows and Linux and releases the artifacts to easily test new commits.

Maybe the future improvements for the CI shall be:
- Add automatic building for client-side for Windows (Linux requires a Makefile).
- Add the tag version and commit in the file name of the artifacts.